### PR TITLE
Updated Github Action to work with MC 1.18.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     strategy:
       matrix:
-        # Use Java 16
-        java: [16]
+        # Use these Java versions
+        java: [17] # Current Java LTS & minimum supported by Minecraft
         # Test on both Linux and Windows
         os: [ubuntu-20.04, windows-latest]
     
@@ -38,7 +38,7 @@ jobs:
       
       - name: capture build artifacts
         # Only capture artifacts from one OS (Linux)
-        if: ${{ runner.os == 'Linux' && matrix.java == '16' }}
+        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
         uses: actions/upload-artifact@v2
         with:
           name: Artifacts


### PR DESCRIPTION
Minecraft 1.18 upwards uses Java 17, so the Github Actions needed a small update there. :)