### PR TITLE
Improve Bedrock Armor model cape rendering

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/mixin/client/CapeFeatureRendererMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/client/CapeFeatureRendererMixin.java
@@ -29,23 +29,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Environment(EnvType.CLIENT)
 @Mixin(CapeFeatureRenderer.class)
 public abstract class CapeFeatureRendererMixin extends FeatureRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
-	
+
 	public CapeFeatureRendererMixin(FeatureRendererContext<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> ctx) {
 		super(ctx);
 	}
-	
+
+    /**
+     * Renders a custom flap on the front of the Bedrock Armor, as well as a custom cape render
+     */
 	@Inject(method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/client/network/AbstractClientPlayerEntity;FFFFFF)V", at = @At("HEAD"), cancellable = true)
 	public void spectrum$renderBedrockCape(MatrixStack ms, VertexConsumerProvider vertices, int light, AbstractClientPlayerEntity player, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
-		// If the player has a cape already, or has disabled their cape from rendering, do not render custom cape
-		if (!player.isPartVisible(PlayerModelPart.CAPE) || player.getCapeTexture() != null) return;
-		
-		// Check if an Elytra is being rendered, and the Fabric Event, and cancel if necessary
-		if (RenderingContext.isElytraRendered || !LivingEntityFeatureRenderEvents.ALLOW_CAPE_RENDER.invoker().allowCapeRender(player))
-			return;
-		
+		// If the player has disabled their cape from rendering, do not render
+		if (!player.isPartVisible(PlayerModelPart.CAPE)) return;
+
 		// Check for the chestplate, and begin rendering the cape if equipped
 		if (player.getEquippedStack(EquipmentSlot.CHEST).getItem() == SpectrumItems.BEDROCK_CHESTPLATE) {
-			
+
 			// Vanilla cape values
 			double x = MathHelper.lerpAngleDegrees(h / 2, (float) player.prevCapeX, (float) player.capeX)
 					- MathHelper.lerpAngleDegrees(h / 2, (float) player.prevX, (float) player.getX());
@@ -60,51 +59,61 @@ public abstract class CapeFeatureRendererMixin extends FeatureRenderer<AbstractC
 			q = MathHelper.clamp(q, -6.0F, 32.0F);
 			float r = (float) (x * o + z * p) * 100.0F;
 			r = MathHelper.clamp(r, 0.0F, 150.0F);
-			float s = (float) (x * p - z * o) * 100.0F;
-			s = MathHelper.clamp(s, -20.0F, 20.0F);
+			float capeZOffset = (float) (x * p - z * o) * 100.0F;
+			capeZOffset = MathHelper.clamp(capeZOffset, -20.0F, 20.0F);
 			if (r < 0.0F) {
 				r = 0.0F;
 			}
-			
-			
+
+
 			float t = MathHelper.lerp(h, player.prevStrideDistance, player.strideDistance);
 			q += MathHelper.sin(MathHelper.lerp(h, player.prevHorizontalSpeed, player.horizontalSpeed) * 6.0F) * 32.0F * t;
-			
+
 			if (player.isInSneakingPose()) {
 				q += 25.0F;
 			}
-			
-			float backCapeRotation = MathHelper.clamp(6.0F + r / 2.0F + q, -30, 60);
+
 			float frontCapeRotation = MathHelper.clamp(-(6.0F + r / 2.0F + q), -25, 0);
-			
+
+            // Transform and render front cloth
+            VertexConsumer vertexConsumer = vertices.getBuffer(RenderLayer.getEntitySolid(SpectrumModelLayers.BEDROCK_ARMOR_LOCATION));
+            ms.push();
+            ms.translate(0, 0.35, 0);
+            ms.multiply(Vec3f.POSITIVE_X.getDegreesQuaternion(frontCapeRotation));
+            if (!player.isInSneakingPose()) {
+                ms.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(capeZOffset / 2.0F));
+            }
+
+            // Make some space for your legs if crouching
+            ms.translate(0, -0.65, -0.15);
+            if (player.isInSneakingPose()) {
+                ms.translate(0, 0.05, 0.35);
+            }
+            BedrockArmorCapeModel.FRONT_CLOTH.render(ms, vertexConsumer, light, OverlayTexture.DEFAULT_UV);
+            ms.pop();
+
+            // Respect the players own cape, Elytras and Fabrics Render Event
+            if (player.getCapeTexture() != null || RenderingContext.isElytraRendered || !LivingEntityFeatureRenderEvents.ALLOW_CAPE_RENDER.invoker().allowCapeRender(player)) {
+                return;
+            }
+
+            float backCapeRotation = MathHelper.clamp(6.0F + r / 2.0F + q, -30, 60);
+
 			// Transform and render the custom cape
 			ms.push();
 			ms.translate(0, -0.05, 0.0); // Push up and backwards, then rotate
 			ms.multiply(Vec3f.POSITIVE_X.getDegreesQuaternion(backCapeRotation));
-			ms.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(s / 2.0F));
-			ms.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(180.0F - s / 1.25F));
+			ms.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(capeZOffset / 2.0F));
+			ms.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(180.0F - capeZOffset / 1.25F));
 			ms.translate(0, 0.05, -0.325); // Move back down
 			if (player.isInSneakingPose()) {
 				ms.translate(0, 0.15, 0.125);
 			}
-			VertexConsumer vertexConsumer = vertices.getBuffer(RenderLayer.getEntitySolid(SpectrumModelLayers.BEDROCK_ARMOR_LOCATION));
+
 			BedrockArmorCapeModel.CAPE_MODEL.render(ms, vertexConsumer, light, OverlayTexture.DEFAULT_UV);
 			ms.pop();
-			
-			// Transform and render front cloth
-			ms.push();
-			ms.translate(0, 0.35, 0);
-			ms.multiply(Vec3f.POSITIVE_X.getDegreesQuaternion(frontCapeRotation));
-			if (!player.isInSneakingPose()) {
-				ms.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(s / 2.0F));
-			}
-			ms.translate(0, -0.65, -0.15);
-			if (player.isInSneakingPose()) {
-				ms.translate(0, 0.05, 0.35);
-			}
-			BedrockArmorCapeModel.FRONT_CLOTH.render(ms, vertexConsumer, light, OverlayTexture.DEFAULT_UV);
-			ms.pop();
-			
+
+            // Cancel any other capes from rendering
 			ci.cancel();
 		}
 	}

--- a/src/main/java/de/dafuqs/spectrum/render/armor/BedrockArmorModel.java
+++ b/src/main/java/de/dafuqs/spectrum/render/armor/BedrockArmorModel.java
@@ -1,9 +1,6 @@
 package de.dafuqs.spectrum.render.armor;
 
-import net.minecraft.client.model.ModelData;
-import net.minecraft.client.model.ModelPart;
-import net.minecraft.client.model.ModelPartBuilder;
-import net.minecraft.client.model.ModelTransform;
+import net.minecraft.client.model.*;
 
 public class BedrockArmorModel {
 	public final ModelPart head;
@@ -57,7 +54,7 @@ public class BedrockArmorModel {
 				ModelPartBuilder.create(),
 				ModelTransform.NONE
 		);
-		
+
 		var armorRightArm = rightArm.addChild(
 				"armor_right_arm",
 				ModelPartBuilder.create()
@@ -65,13 +62,13 @@ public class BedrockArmorModel {
 						.cuboid(-4.25F, -2.5F, -2.5F, 5.0F, 13.0F, 5.0F),
 				ModelTransform.pivot(1.0F, 0.0F, 0.0F)
 		);
-		
+
 		armorRightArm.addChild(
 				"armor_right_arm_extra",
 				ModelPartBuilder.create()
 						.uv(57, 45)
-						.cuboid(-4.0F, -1.5F, -3.0F, 6.0F, 4.0F, 6.0F),
-				ModelTransform.of(-1.5F, -1.5F, 0.0F, 0.0F, 0.0F, -0.4363F)
+						.cuboid(-4.0F, -1.5F, -3.0F, 6.0F, 4.0F, 6.0F, new Dilation(0.10F)),
+				ModelTransform.of(-1.5F, -2.0F, 0.0F, 0.0F, 0.0F, -0.4363F)
 		);
 		
 		var leftArm = root.addChild(
@@ -92,10 +89,10 @@ public class BedrockArmorModel {
 				"armor_left_arm_extra",
 				ModelPartBuilder.create()
 						.uv(62, 20)
-						.cuboid(-1.75F, -1.25F, -2.0F, 5.0F, 1.0F, 5.0F)
+						.cuboid(-1.75F, -1.25F, -2.0F, 5.0F, 1.0F, 5.0F, new Dilation(0.10F))
 						.uv(54, 12)
-						.cuboid(-1.75F, -0.25F, -2.5F, 6.0F, 2.0F, 6.0F),
-				ModelTransform.of(1.0F, -1.75F, -0.5F, 0.0F, 0.0F, 0.4363F)
+						.cuboid(-1.75F, -0.25F, -2.5F, 6.0F, 2.0F, 6.0F, new Dilation(0.10F)),
+				ModelTransform.of(1.0F, -2.25F, -0.5F, 0.0F, 0.0F, 0.4363F)
 		);
 		
 		var leftLeg = root.addChild(


### PR DESCRIPTION
Reduces the shoulder clipping, and does not disable the front flap from being rendered when another cape, or Elytra, is present.
If you disable cape rendering on a skin level you will disable both the cape and the front flap. 

![image](https://user-images.githubusercontent.com/4163353/218485929-7a8a3c62-ec8f-44a7-bfbd-3170bfd303f5.png)


Signed-off-by: Noaaan <noaaan@hotmail.com>