### PR TITLE
Comparator support for chests

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/chests/SpectrumChestBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/chests/SpectrumChestBlock.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.ai.pathing.NavigationType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.DirectionProperty;
@@ -51,6 +52,17 @@ public abstract class SpectrumChestBlock extends BlockWithEntity {
 	
 	public abstract void openScreen(World world, BlockPos pos, PlayerEntity player);
 	
+	@Override
+    public boolean hasComparatorOutput(BlockState state) {
+        return true;
+    }
+	
+	@Override
+    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		return ScreenHandler.calculateComparatorOutput(world.getBlockEntity(pos));
+    }
+	
+	@Override
 	public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
 		if (!state.isOf(newState.getBlock())) {
 			BlockEntity blockEntity = world.getBlockEntity(pos);


### PR DESCRIPTION
This PR adds comparator support for all Spectrum chests.

Note: There are a number of other blocks that might be worthwhile to add comparator support to. The placeable inventories that don't currently output a comparator signal are presents, bottomless bundles, color picker, crystal apothecary, potion workshop, and titration barrel. Also, maybe idols should emit some signal when they're triggered.