### PR TITLE
Comparator support for all other Spectrum inventories

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleBlock.java
@@ -102,11 +102,41 @@ public class BottomlessBundleBlock extends BlockWithEntity {
 	}
 	
 	@Override
+    public boolean hasComparatorOutput(BlockState state) {
+        return true;
+    }
+	
+	@Override
+    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		BlockEntity blockEntity = world.getBlockEntity(pos);
+		if (blockEntity instanceof BottomlessBundleBlockEntity bottomlessBundleBlockEntity) {
+			float curr = bottomlessBundleBlockEntity.storage.amount;
+			float max = bottomlessBundleBlockEntity.storage.getCapacity();
+			return MathHelper.floor(curr / max * 14.0f) + curr > 0 ? 1 : 0;
+		}
+		
+		return 0;
+    }
+	
+	@Override
+	public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
+		if (!state.isOf(newState.getBlock())) {
+			BlockEntity blockEntity = world.getBlockEntity(pos);
+			if (blockEntity instanceof BottomlessBundleBlockEntity bottomlessBundleBlockEntity) {
+				world.updateComparators(pos, this);
+			}
+			
+			super.onStateReplaced(state, world, pos, newState, moved);
+		}
+	}
+	
+	@Override
 	public void onPlaced(World world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack itemStack) {
 		if (!world.isClient) {
 			BlockEntity blockEntity = world.getBlockEntity(pos);
 			if (blockEntity instanceof BottomlessBundleBlockEntity bottomlessBundleBlockEntity) {
 				bottomlessBundleBlockEntity.setBundle(itemStack.copy());
+				world.updateComparators(pos, this);
 			}
 		}
 	}

--- a/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
@@ -223,12 +223,12 @@ public class BottomlessBundleItem extends BundleItem implements InventoryInserti
 			if (compound.contains("Locked")) {
 				compound.remove("Locked");
 				if (world.isClient) {
-					plaZipSound(user, 0.8F);
+					playZipSound(user, 0.8F);
 				}
 			} else {
 				compound.putBoolean("Locked", true);
 				if (world.isClient) {
-					plaZipSound(user, 1.0F);
+					playZipSound(user, 1.0F);
 				}
 			}
 			return TypedActionResult.success(itemStack, world.isClient());
@@ -470,7 +470,7 @@ public class BottomlessBundleItem extends BundleItem implements InventoryInserti
 		entity.playSound(SoundEvents.ITEM_BUNDLE_DROP_CONTENTS, 0.8F, 0.8F + entity.getWorld().getRandom().nextFloat() * 0.4F);
 	}
 	
-	private void plaZipSound(Entity entity, float basePitch) {
+	private void playZipSound(Entity entity, float basePitch) {
 		entity.playSound(SpectrumSoundEvents.BOTTOMLESS_BUNDLE_ZIP, 0.8F, basePitch + entity.getWorld().getRandom().nextFloat() * 0.4F);
 	}
 	

--- a/src/main/java/de/dafuqs/spectrum/blocks/energy/ColorPickerBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/energy/ColorPickerBlock.java
@@ -16,6 +16,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.ItemScatterer;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
@@ -81,6 +82,28 @@ public class ColorPickerBlock extends BlockWithEntity {
 			player.openHandledScreen(colorPickerBlockEntity);
 		}
 	}
+	
+	@Override
+    public boolean hasComparatorOutput(BlockState state) {
+        return true;
+    }
+	
+	@Override
+    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		if(world.getBlockEntity(pos) instanceof ColorPickerBlockEntity blockEntity) {
+			int i = 0;
+			float f = 0.0f;
+			for (int j = 0; j < blockEntity.inventory.size(); ++j) {
+				ItemStack itemStack = blockEntity.inventory.get(j);
+				if (itemStack.isEmpty()) continue;
+				f += (float)itemStack.getCount() / (float)itemStack.getMaxCount();
+				++i;
+			}
+			return MathHelper.floor((f /= (float)blockEntity.inventory.size()) * 14.0f) + (i > 0 ? 1 : 0);
+		}
+		
+		return 0;
+    }
 	
 	@Override
 	public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {

--- a/src/main/java/de/dafuqs/spectrum/blocks/energy/CrystalApothecaryBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/energy/CrystalApothecaryBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.pathing.NavigationType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
@@ -72,6 +73,16 @@ public class CrystalApothecaryBlock extends BlockWithEntity {
 			return ActionResult.CONSUME;
 		}
 	}
+	
+	@Override
+    public boolean hasComparatorOutput(BlockState state) {
+        return true;
+    }
+	
+	@Override
+    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		return ScreenHandler.calculateComparatorOutput(world.getBlockEntity(pos));
+    }
 	
 	@Override
 	public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {

--- a/src/main/java/de/dafuqs/spectrum/blocks/fusion_shrine/FusionShrineBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fusion_shrine/FusionShrineBlock.java
@@ -18,6 +18,7 @@ import net.minecraft.state.*;
 import net.minecraft.state.property.*;
 import net.minecraft.text.*;
 import net.minecraft.util.*;
+import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.hit.*;
 import net.minecraft.util.math.*;
 import net.minecraft.util.shape.*;
@@ -94,6 +95,31 @@ public class FusionShrineBlock extends InWorldInteractionBlock {
 	public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
 		return new FusionShrineBlockEntity(pos, state);
 	}
+	
+	@Override
+    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		if(world.getBlockEntity(pos) instanceof FusionShrineBlockEntity blockEntity) {
+			DefaultedList<ItemStack> inventory = blockEntity.getItems();
+			
+			int i = 0;
+	        float f = 0.0f;
+	        for (int j = 0; j < inventory.size(); ++j) {
+	            ItemStack itemStack = blockEntity.getStack(j);
+	            if (itemStack.isEmpty()) continue;
+	            f += (float)itemStack.getCount() / (float)Math.min(blockEntity.getMaxCountPerStack(), itemStack.getMaxCount());
+	            ++i;
+	        }
+			
+			if (blockEntity.fluidStorage.amount > 0) {
+				f += (float)blockEntity.fluidStorage.amount / (float)blockEntity.fluidStorage.getCapacity();
+				++i;
+			}
+			
+	        return MathHelper.floor((f /= ((float)inventory.size()+1)) * 14.0f) + (i > 0 ? 1 : 0);
+		}
+		
+		return 0;
+    }
 	
 	@Override
 	public void onBroken(WorldAccess world, BlockPos pos, BlockState state) {

--- a/src/main/java/de/dafuqs/spectrum/blocks/potion_workshop/PotionWorkshopBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/potion_workshop/PotionWorkshopBlock.java
@@ -9,6 +9,7 @@ import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.entity.ai.pathing.NavigationType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.screen.ScreenHandler;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.util.ActionResult;
@@ -67,6 +68,16 @@ public class PotionWorkshopBlock extends BlockWithEntity {
 	public BlockRenderType getRenderType(BlockState state) {
 		return BlockRenderType.MODEL;
 	}
+	
+	@Override
+    public boolean hasComparatorOutput(BlockState state) {
+        return true;
+    }
+	
+	@Override
+    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		return ScreenHandler.calculateComparatorOutput(world.getBlockEntity(pos));
+    }
 	
 	public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
 		if (!(newState.getBlock() instanceof PotionWorkshopBlock)) {

--- a/src/main/java/de/dafuqs/spectrum/blocks/titration_barrel/TitrationBarrelBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/titration_barrel/TitrationBarrelBlock.java
@@ -11,6 +11,7 @@ import net.minecraft.block.entity.*;
 import net.minecraft.entity.player.*;
 import net.minecraft.fluid.*;
 import net.minecraft.item.*;
+import net.minecraft.screen.ScreenHandler;
 import net.minecraft.server.network.*;
 import net.minecraft.sound.*;
 import net.minecraft.state.*;
@@ -204,12 +205,34 @@ public class TitrationBarrelBlock extends HorizontalFacingBlock implements Block
 		builder.add(FACING, BARREL_STATE);
 	}
 	
+	@Override
+    public boolean hasComparatorOutput(BlockState state) {
+        return true;
+    }
+	
+	@Override
+    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		if(world.getBlockEntity(pos) instanceof TitrationBarrelBlockEntity blockEntity) {
+			float icurr = InventoryHelper.countItemsInInventory(blockEntity.inventory);
+			float imax = TitrationBarrelBlockEntity.MAX_ITEM_COUNT;
+			
+			float fcurr = blockEntity.fluidStorage.amount;
+			float fmax = blockEntity.fluidStorage.getCapacity();
+			
+			return MathHelper.floor(icurr / imax * 13.0f + fcurr / fmax) + (blockEntity.inventory.isEmpty() ? 0 : 1);
+		}
+		
+		return 0;
+    }
+	
 	// drop all currently stored items
 	@Override
 	public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
 		if (!newState.isOf(this) && state.get(BARREL_STATE) == BarrelState.FILLED) {
 			scatterContents(world, pos);
+			world.updateComparators(pos, this);
 		}
+		
 		super.onStateReplaced(state, world, pos, newState, moved);
 	}
 	

--- a/src/main/java/de/dafuqs/spectrum/blocks/titration_barrel/TitrationBarrelBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/titration_barrel/TitrationBarrelBlock.java
@@ -235,7 +235,7 @@ public class TitrationBarrelBlock extends HorizontalFacingBlock implements Block
 					float fcurr = blockEntity.fluidStorage.amount;
 					float fmax = blockEntity.fluidStorage.getCapacity();
 					
-					return MathHelper.floor(icurr / imax * 13.0f + fcurr / fmax) + isNotEmpty;
+					return MathHelper.floor(((icurr / imax) + (fcurr / fmax)) / 2.0f * 14.0f) + isNotEmpty;
 				}
 				
 				case SEALED: {

--- a/src/main/java/de/dafuqs/spectrum/items/trinkets/GlowVisionGogglesItem.java
+++ b/src/main/java/de/dafuqs/spectrum/items/trinkets/GlowVisionGogglesItem.java
@@ -1,6 +1,9 @@
 package de.dafuqs.spectrum.items.trinkets;
 
 import de.dafuqs.spectrum.SpectrumCommon;
+import de.dafuqs.spectrum.energy.InkPowered;
+import de.dafuqs.spectrum.energy.color.InkColor;
+import de.dafuqs.spectrum.energy.color.InkColors;
 import de.dafuqs.spectrum.helpers.InventoryHelper;
 import de.dafuqs.spectrum.registries.SpectrumSoundEvents;
 import dev.emi.trinkets.api.SlotReference;
@@ -17,9 +20,14 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class GlowVisionGogglesItem extends SpectrumTrinketItem {
+public class GlowVisionGogglesItem extends SpectrumTrinketItem implements InkPowered {
 	
-	public static ItemStack COST = new ItemStack(Items.GLOW_INK_SAC, 1);
+	// White makes more sense, as it's the color of life, _light_, and
+	// purity, but it's not acquired for a bit. Also, glow ink is blue.
+	// public static final InkColor USED_COLOR = InkColors.WHITE;
+	public static final InkColor USED_COLOR = InkColors.BLUE;
+	public static final int INK_COST = 20;
+	public static ItemStack ITEM_COST = new ItemStack(Items.GLOW_INK_SAC, 1);
 	
 	public GlowVisionGogglesItem(Settings settings) {
 		super(settings, SpectrumCommon.locate("progression/unlock_glow_vision_goggles"));
@@ -39,7 +47,15 @@ public class GlowVisionGogglesItem extends SpectrumTrinketItem {
 					if (nightVisionInstance == null || nightVisionInstance.getDuration() < 10 * 20) { // prevent "night vision running out" flashing
 						// no / short night vision => search for glow ink sac and add night vision if found
 						
-						if (InventoryHelper.removeFromInventoryWithRemainders(serverPlayerEntity, COST)) {
+						boolean paid = serverPlayerEntity.isCreative();
+						if (!paid) { // try pay with ink
+							paid = InkPowered.tryDrainEnergy(serverPlayerEntity, USED_COLOR, INK_COST);
+						}
+						if (!paid) {  // try pay with item
+							paid = InventoryHelper.removeFromInventoryWithRemainders(serverPlayerEntity, ITEM_COST);
+						}
+						
+						if (paid) {
 							StatusEffectInstance newNightVisionInstance = new StatusEffectInstance(StatusEffects.NIGHT_VISION, 20 * SpectrumCommon.CONFIG.GlowVisionGogglesDuration);
 							serverPlayerEntity.addStatusEffect(newNightVisionInstance);
 							world.playSoundFromEntity(null, serverPlayerEntity, SpectrumSoundEvents.ITEM_ARMOR_EQUIP_GLOW_VISION, SoundCategory.PLAYERS, 0.2F, 1.0F);
@@ -56,4 +72,8 @@ public class GlowVisionGogglesItem extends SpectrumTrinketItem {
 		tooltip.add(Text.translatable("item.spectrum.glow_vision_goggles.tooltip"));
 	}
 	
+	@Override
+	public List<InkColor> getUsedColors() {
+		return List.of(USED_COLOR);
+	}
 }

--- a/src/main/java/de/dafuqs/spectrum/items/trinkets/GlowVisionGogglesItem.java
+++ b/src/main/java/de/dafuqs/spectrum/items/trinkets/GlowVisionGogglesItem.java
@@ -22,10 +22,7 @@ import java.util.List;
 
 public class GlowVisionGogglesItem extends SpectrumTrinketItem implements InkPowered {
 	
-	// White makes more sense, as it's the color of life, _light_, and
-	// purity, but it's not acquired for a bit. Also, glow ink is blue.
-	// public static final InkColor USED_COLOR = InkColors.WHITE;
-	public static final InkColor USED_COLOR = InkColors.BLUE;
+	public static final InkColor USED_COLOR = InkColors.LIGHT_BLUE;
 	public static final int INK_COST = 20;
 	public static ItemStack ITEM_COST = new ItemStack(Items.GLOW_INK_SAC, 1);
 	


### PR DESCRIPTION
This PR adds comparator support for titration barrels, bottomless bundles, crystal apothecaries, potion workshops, and color pickers. It also makes the fluid content in titration barrels and fusion shrines contribute to the output.