### PR TITLE
Fixed kelp-induced infinite black materia

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/decay/BlackMateriaBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/decay/BlackMateriaBlock.java
@@ -60,8 +60,9 @@ public class BlackMateriaBlock extends FallingBlock {
 	
 	@Override
     public void onDestroyedOnLanding(World world, BlockPos pos, FallingBlockEntity fallingBlockEntity) {
-		// To prevent infinite materia, we eat any non-solid blocks that we land on. Since the block item
-		// is going to be dropped regardless, we just replace the non-solid block with air.
-		world.setBlockState(pos, Blocks.AIR.getDefaultState());
+		BlockState state = world.getBlockState(pos);
+		if(state.isOf(Blocks.KELP_PLANT) || state.isOf(Blocks.KELP)) {
+			world.setBlockState(pos, Blocks.WATER.getDefaultState().with(FluidBlock.LEVEL, 15));
+		}
     }
 }

--- a/src/main/java/de/dafuqs/spectrum/blocks/decay/BlackMateriaBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/decay/BlackMateriaBlock.java
@@ -2,6 +2,7 @@ package de.dafuqs.spectrum.blocks.decay;
 
 import de.dafuqs.spectrum.registries.*;
 import net.minecraft.block.*;
+import net.minecraft.entity.FallingBlockEntity;
 import net.minecraft.server.world.*;
 import net.minecraft.sound.*;
 import net.minecraft.state.*;
@@ -57,4 +58,10 @@ public class BlackMateriaBlock extends FallingBlock {
 		builder.add(AGE);
 	}
 	
+	@Override
+    public void onDestroyedOnLanding(World world, BlockPos pos, FallingBlockEntity fallingBlockEntity) {
+		// To prevent infinite materia, we eat any non-solid blocks that we land on. Since the block item
+		// is going to be dropped regardless, we just replace the non-solid block with air.
+		world.setBlockState(pos, Blocks.AIR.getDefaultState());
+    }
 }


### PR DESCRIPTION
This PR adds a quick fix for midnight solution creating infinite black materia when above kelp. This could be made to apply to other non-solid blocks as well, to prevent infinite materia generally, but that would take careful consideration to avoid destroying things like ender portals when materia lands on them.