### PR TITLE
Allow Loot Tables to be used with Item Bowls and Item Roundel

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/InWorldInteractionBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/InWorldInteractionBlockEntity.java
@@ -1,14 +1,20 @@
 package de.dafuqs.spectrum.blocks;
 
+import net.minecraft.advancement.criterion.*;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.*;
+import net.minecraft.entity.player.*;
 import net.minecraft.inventory.*;
 import net.minecraft.item.*;
+import net.minecraft.loot.*;
+import net.minecraft.loot.context.*;
 import net.minecraft.nbt.*;
 import net.minecraft.network.*;
 import net.minecraft.network.listener.*;
 import net.minecraft.network.packet.s2c.play.*;
+import net.minecraft.server.network.*;
 import net.minecraft.server.world.*;
+import net.minecraft.util.*;
 import net.minecraft.util.collection.*;
 import net.minecraft.util.math.*;
 import org.jetbrains.annotations.*;
@@ -16,7 +22,10 @@ import org.jetbrains.annotations.*;
 public abstract class InWorldInteractionBlockEntity extends BlockEntity implements ImplementedInventory {
 	
 	private final int inventorySize;
-	private DefaultedList<ItemStack> items;
+	protected DefaultedList<ItemStack> items;
+	@Nullable
+	protected Identifier lootTableId;
+	protected long lootTableSeed;
 	
 	public InWorldInteractionBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state, int inventorySize) {
 		super(type, pos, state);
@@ -49,6 +58,50 @@ public abstract class InWorldInteractionBlockEntity extends BlockEntity implemen
 		super.writeNbt(nbt);
 		Inventories.writeNbt(nbt, items);
 	}
+	protected boolean deserializeLootTable(NbtCompound nbt) {
+		if (nbt.contains("LootTable", NbtElement.STRING_TYPE)) {
+			this.lootTableId = new Identifier(nbt.getString("LootTable"));
+			this.lootTableSeed = nbt.getLong("LootTableSeed");
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	protected boolean serializeLootTable(NbtCompound nbt) {
+		if (this.lootTableId == null) {
+			return false;
+		} else {
+			nbt.putString("LootTable", this.lootTableId.toString());
+			if (this.lootTableSeed != 0L) {
+				nbt.putLong("LootTableSeed", this.lootTableSeed);
+			}
+
+			return true;
+		}
+	}
+
+	public void checkLootInteraction(@Nullable PlayerEntity player) {
+		var world = this.getWorld();
+		if (world != null && this.lootTableId != null && world.getServer() != null) {
+			LootTable lootTable = world.getServer().getLootManager().getTable(this.lootTableId);
+			if (player instanceof ServerPlayerEntity) {
+				Criteria.PLAYER_GENERATES_CONTAINER_LOOT.trigger((ServerPlayerEntity)player, this.lootTableId);
+			}
+
+			this.lootTableId = null;
+			LootContext.Builder builder = new LootContext.Builder((ServerWorld) world)
+				.parameter(LootContextParameters.ORIGIN, Vec3d.ofCenter(this.pos))
+				.random(this.lootTableSeed);
+			if (player != null) {
+				builder.luck(player.getLuck()).parameter(LootContextParameters.THIS_ENTITY, player);
+			}
+
+			lootTable.supplyInventory(this, builder.build(LootContextTypes.CHEST));
+		}
+
+	}
+
 	
 	@Nullable
 	@Override

--- a/src/main/java/de/dafuqs/spectrum/blocks/item_bowl/ItemBowlBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/item_bowl/ItemBowlBlockEntity.java
@@ -12,7 +12,9 @@ import de.dafuqs.spectrum.registries.color.*;
 import net.minecraft.block.*;
 import net.minecraft.client.world.*;
 import net.minecraft.entity.*;
+import net.minecraft.inventory.*;
 import net.minecraft.item.*;
+import net.minecraft.nbt.*;
 import net.minecraft.particle.*;
 import net.minecraft.server.world.*;
 import net.minecraft.sound.*;
@@ -29,6 +31,28 @@ public class ItemBowlBlockEntity extends InWorldInteractionBlockEntity {
 	
 	public ItemBowlBlockEntity(BlockPos pos, BlockState state) {
 		super(SpectrumBlockEntities.ITEM_BOWL, pos, state, INVENTORY_SIZE);
+	}
+
+	@Override
+	public void readNbt(NbtCompound nbt) {
+		super.readNbt(nbt);
+		if (!this.deserializeLootTable(nbt)) {
+			Inventories.readNbt(nbt, this.items);
+		}
+	}
+
+	@Override
+	public void writeNbt(NbtCompound nbt) {
+		super.writeNbt(nbt);
+		if (!this.serializeLootTable(nbt)) {
+			Inventories.writeNbt(nbt, this.items);
+		}
+	}
+
+	@Override
+	public NbtCompound toInitialChunkDataNbt() {
+		this.checkLootInteraction(null);
+		return super.toInitialChunkDataNbt();
 	}
 	
 	public static void clientTick(@NotNull World world, BlockPos blockPos, BlockState blockState, ItemBowlBlockEntity itemBowlBlockEntity) {

--- a/src/main/java/de/dafuqs/spectrum/blocks/item_roundel/ItemRoundelBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/item_roundel/ItemRoundelBlockEntity.java
@@ -4,6 +4,8 @@ import de.dafuqs.spectrum.blocks.*;
 import de.dafuqs.spectrum.registries.*;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.*;
+import net.minecraft.inventory.*;
+import net.minecraft.nbt.*;
 import net.minecraft.util.math.*;
 
 public class ItemRoundelBlockEntity extends InWorldInteractionBlockEntity {
@@ -21,5 +23,26 @@ public class ItemRoundelBlockEntity extends InWorldInteractionBlockEntity {
 	public boolean renderStacksAsIndividualItems() {
 		return false;
 	}
-	
+
+	@Override
+	public void readNbt(NbtCompound nbt) {
+		super.readNbt(nbt);
+		if (!this.deserializeLootTable(nbt)) {
+			Inventories.readNbt(nbt, this.items);
+		}
+	}
+
+	@Override
+	public void writeNbt(NbtCompound nbt) {
+		super.writeNbt(nbt);
+		if (!this.serializeLootTable(nbt)) {
+			Inventories.writeNbt(nbt, this.items);
+		}
+	}
+
+	@Override
+	public NbtCompound toInitialChunkDataNbt() {
+		this.checkLootInteraction(null);
+		return super.toInitialChunkDataNbt();
+	}
 }


### PR DESCRIPTION
Technically also applies to any of the crafting stations, as they also extend the InWorldInteractionBlockEntity, which this has been implemented upon.

Based upon code from LootableContainerBlockEntity

Did you know that Hoppers can accept Loot Tables when placed? Crazy stuff.