### PR TITLE
Update moonstone_chiseled_basalt_mirrored.png.mcmeta

### DIFF
--- a/src/main/resources/assets/spectrum/textures/block/moonstone_chiseled_basalt_mirrored.png.mcmeta
+++ b/src/main/resources/assets/spectrum/textures/block/moonstone_chiseled_basalt_mirrored.png.mcmeta
@@ -1,5 +1,6 @@
 {
 	"animation": {
-		"frametime": 2
+		"frametime": 2,
+                "interpolate": true
 	}
 }


### PR DESCRIPTION
this one didn't have `"interpolate": true`
but all the other moonstone chiseled `.mcmeta`s did