### PR TITLE
Shimmer Medium level Bud bloom fix

### DIFF
--- a/src/main/resources/assets/spectrum/textures/block/medium_citrine_bud.png.mcmeta
+++ b/src/main/resources/assets/spectrum/textures/block/medium_citrine_bud.png.mcmeta
@@ -1,0 +1,5 @@
+{
+    "shimmer": {
+        "bloom": true
+    }
+}

--- a/src/main/resources/assets/spectrum/textures/block/medium_moonstone_bud.png.mcmeta
+++ b/src/main/resources/assets/spectrum/textures/block/medium_moonstone_bud.png.mcmeta
@@ -1,0 +1,5 @@
+{
+    "shimmer": {
+        "bloom": true
+    }
+}

--- a/src/main/resources/assets/spectrum/textures/block/medium_onyx_bud.png.mcmeta
+++ b/src/main/resources/assets/spectrum/textures/block/medium_onyx_bud.png.mcmeta
@@ -1,0 +1,5 @@
+{
+    "shimmer": {
+        "bloom": true
+    }
+}

--- a/src/main/resources/assets/spectrum/textures/block/medium_topaz_bud.png.mcmeta
+++ b/src/main/resources/assets/spectrum/textures/block/medium_topaz_bud.png.mcmeta
@@ -1,0 +1,5 @@
+{
+    "shimmer": {
+        "bloom": true
+    }
+}


### PR DESCRIPTION
This pull request will fix all of the primary progression buds in the medium stage not having shimmer bloom properties that was missing for some reason

this is a copy-paste and followed file format based on one of the png.mcmeta for one of the large crystals
this should work hopefuly