### PR TITLE
Fix Quilt related issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 minecraft_version=1.20.1
 yarn_mappings=1.20.1+build.10
-loader_version=0.14.25
+loader_version=0.14.23
 
 # Mod Properties
 mod_version=1.7.2
@@ -13,7 +13,7 @@ archives_base_name=spectrum-1.7.2-deeper-down
 
 # Dependencies
 # https://fabricmc.net/develop/
-fabric_version=0.91.0+1.20.1
+fabric_version=0.90.0+1.20.1
 
 cloth_config_version=11.1.106
 modmenu_version=7.2.1

--- a/src/main/java/de/dafuqs/spectrum/mixin/client/MinecraftClientMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/client/MinecraftClientMixin.java
@@ -19,7 +19,7 @@ public abstract class MinecraftClientMixin {
 	@Nullable
 	public ClientPlayerEntity player;
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getRegistryKey()Lnet/minecraft/util/registry/RegistryKey;"), method = "getMusicType()Lnet/minecraft/sound/MusicSound;", cancellable = true)
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getRegistryKey()Lnet/minecraft/registry/RegistryKey;"), method = "getMusicType()Lnet/minecraft/sound/MusicSound;", cancellable = true)
 	public void spectrum$getMusicType(CallbackInfoReturnable<MusicSound> cir) {
 		if (player.getWorld().getRegistryKey() == SpectrumDimensions.DIMENSION_KEY) {
 			if (Support.hasPlayerFinishedMod(player)) {

--- a/src/main/java/de/dafuqs/spectrum/progression/SpectrumAdvancementCriteria.java
+++ b/src/main/java/de/dafuqs/spectrum/progression/SpectrumAdvancementCriteria.java
@@ -2,6 +2,7 @@ package de.dafuqs.spectrum.progression;
 
 import de.dafuqs.spectrum.progression.advancement.*;
 import net.fabricmc.fabric.mixin.object.builder.*;
+import net.minecraft.advancement.criterion.Criteria;
 
 public class SpectrumAdvancementCriteria {
 
@@ -42,41 +43,41 @@ public class SpectrumAdvancementCriteria {
 	public static PreservationCheckCriterion PRESERVATION_CHECK;
 
 	public static void register() {
-		PEDESTAL_RECIPE_CALCULATED = CriteriaAccessor.callRegister(new PedestalRecipeCalculatedCriterion());
-		PEDESTAL_CRAFTING = CriteriaAccessor.callRegister(new PedestalCraftingCriterion());
-		FUSION_SHRINE_CRAFTING = CriteriaAccessor.callRegister(new FusionShrineCraftingCriterion());
-		COMPLETED_MULTIBLOCK = CriteriaAccessor.callRegister(new CompletedMultiblockCriterion());
-		BLOCK_BROKEN = CriteriaAccessor.callRegister(new BlockBrokenCriterion());
-		TREASURE_HUNTER_DROP = CriteriaAccessor.callRegister(new TreasureHunterDropCriterion());
-		NATURES_STAFF_USE = CriteriaAccessor.callRegister(new NaturesStaffUseCriterion());
-		ENCHANTER_CRAFTING = CriteriaAccessor.callRegister(new EnchanterCraftingCriterion());
-		ENCHANTER_ENCHANTING = CriteriaAccessor.callRegister(new EnchanterEnchantingCriterion());
-		ENCHANTER_UPGRADING = CriteriaAccessor.callRegister(new EnchantmentUpgradedCriterion());
-		INERTIA_USED = CriteriaAccessor.callRegister(new InertiaUsedCriterion());
-		AZURE_DIKE_CHARGE = CriteriaAccessor.callRegister(new AzureDikeChargeCriterion());
-		TRINKET_CHANGE = CriteriaAccessor.callRegister(new TrinketChangeCriterion());
-		POTION_WORKSHOP_BREWING = CriteriaAccessor.callRegister(new PotionWorkshopBrewingCriterion());
-		POTION_WORKSHOP_CRAFTING = CriteriaAccessor.callRegister(new PotionWorkshopCraftingCriterion());
-		TAKE_OFF_BELT_JUMP = CriteriaAccessor.callRegister(new TakeOffBeltJumpCriterion());
-		INK_CONTAINER_INTERACTION = CriteriaAccessor.callRegister(new InkContainerInteractionCriterion());
-		JEOPARDANT_KILL = CriteriaAccessor.callRegister(new JeopardantKillCriterion());
-		MEMORY_MANIFESTING = CriteriaAccessor.callRegister(new MemoryManifestingCriterion());
-		SPIRIT_INSTILLER_CRAFTING = CriteriaAccessor.callRegister(new SpiritInstillerCraftingCriterion());
-		SLIME_SIZING = CriteriaAccessor.callRegister(new SlimeSizingCriterion());
-		CRYSTAL_APOTHECARY_COLLECTING = CriteriaAccessor.callRegister(new CrystalApothecaryCollectingCriterion());
-		UPGRADE_PLACING = CriteriaAccessor.callRegister(new UpgradePlaceCriterion());
-		CRYSTALLARIEUM_GROWING = CriteriaAccessor.callRegister(new CrystallarieumGrownCriterion());
-		CINDERHEARTH_SMELTING = CriteriaAccessor.callRegister(new CinderhearthSmeltingCriterion());
-		KILLED_BY_INK_PROJECTILE = CriteriaAccessor.callRegister(new InkProjectileKillingCriterion());
-		FISHING_ROD_HOOKED = CriteriaAccessor.callRegister(new SpectrumFishingRodHookedCriterion());
-		TITRATION_BARREL_TAPPING = CriteriaAccessor.callRegister(new TitrationBarrelTappingCriterion());
-		CONFIRMATION_BUTTON_PRESSED = CriteriaAccessor.callRegister(new ConfirmationButtonPressedCriterion());
-		BLOOD_ORCHID_PLUCKING = CriteriaAccessor.callRegister(new BloodOrchidPluckingCriterion());
-		DIVINITY_TICK = CriteriaAccessor.callRegister(new DivinityTickCriterion());
-		CONSUMED_TEA_WITH_SCONE = CriteriaAccessor.callRegister(new ConsumedTeaWithSconeCriterion());
-		CREATE_HUMMINGSTONE_HYMN = CriteriaAccessor.callRegister(new HummingstoneHymnCriterion());
-		PASTEL_NETWORK_CREATING = CriteriaAccessor.callRegister(new PastelNetworkCreatingCriterion());
-		PRESERVATION_CHECK = CriteriaAccessor.callRegister(new PreservationCheckCriterion());
+		PEDESTAL_RECIPE_CALCULATED = Criteria.register(new PedestalRecipeCalculatedCriterion());
+		PEDESTAL_CRAFTING = Criteria.register(new PedestalCraftingCriterion());
+		FUSION_SHRINE_CRAFTING = Criteria.register(new FusionShrineCraftingCriterion());
+		COMPLETED_MULTIBLOCK = Criteria.register(new CompletedMultiblockCriterion());
+		BLOCK_BROKEN = Criteria.register(new BlockBrokenCriterion());
+		TREASURE_HUNTER_DROP = Criteria.register(new TreasureHunterDropCriterion());
+		NATURES_STAFF_USE = Criteria.register(new NaturesStaffUseCriterion());
+		ENCHANTER_CRAFTING = Criteria.register(new EnchanterCraftingCriterion());
+		ENCHANTER_ENCHANTING = Criteria.register(new EnchanterEnchantingCriterion());
+		ENCHANTER_UPGRADING = Criteria.register(new EnchantmentUpgradedCriterion());
+		INERTIA_USED = Criteria.register(new InertiaUsedCriterion());
+		AZURE_DIKE_CHARGE = Criteria.register(new AzureDikeChargeCriterion());
+		TRINKET_CHANGE = Criteria.register(new TrinketChangeCriterion());
+		POTION_WORKSHOP_BREWING = Criteria.register(new PotionWorkshopBrewingCriterion());
+		POTION_WORKSHOP_CRAFTING = Criteria.register(new PotionWorkshopCraftingCriterion());
+		TAKE_OFF_BELT_JUMP = Criteria.register(new TakeOffBeltJumpCriterion());
+		INK_CONTAINER_INTERACTION = Criteria.register(new InkContainerInteractionCriterion());
+		JEOPARDANT_KILL = Criteria.register(new JeopardantKillCriterion());
+		MEMORY_MANIFESTING = Criteria.register(new MemoryManifestingCriterion());
+		SPIRIT_INSTILLER_CRAFTING = Criteria.register(new SpiritInstillerCraftingCriterion());
+		SLIME_SIZING = Criteria.register(new SlimeSizingCriterion());
+		CRYSTAL_APOTHECARY_COLLECTING = Criteria.register(new CrystalApothecaryCollectingCriterion());
+		UPGRADE_PLACING = Criteria.register(new UpgradePlaceCriterion());
+		CRYSTALLARIEUM_GROWING = Criteria.register(new CrystallarieumGrownCriterion());
+		CINDERHEARTH_SMELTING = Criteria.register(new CinderhearthSmeltingCriterion());
+		KILLED_BY_INK_PROJECTILE = Criteria.register(new InkProjectileKillingCriterion());
+		FISHING_ROD_HOOKED = Criteria.register(new SpectrumFishingRodHookedCriterion());
+		TITRATION_BARREL_TAPPING = Criteria.register(new TitrationBarrelTappingCriterion());
+		CONFIRMATION_BUTTON_PRESSED = Criteria.register(new ConfirmationButtonPressedCriterion());
+		BLOOD_ORCHID_PLUCKING = Criteria.register(new BloodOrchidPluckingCriterion());
+		DIVINITY_TICK = Criteria.register(new DivinityTickCriterion());
+		CONSUMED_TEA_WITH_SCONE = Criteria.register(new ConsumedTeaWithSconeCriterion());
+		CREATE_HUMMINGSTONE_HYMN = Criteria.register(new HummingstoneHymnCriterion());
+		PASTEL_NETWORK_CREATING = Criteria.register(new PastelNetworkCreatingCriterion());
+		PRESERVATION_CHECK = Criteria.register(new PreservationCheckCriterion());
 	}
 	
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -59,8 +59,8 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.14.25",
-    "fabric-api": ">=0.91.0",
+    "fabricloader": ">=0.14.23",
+    "fabric-api": ">=0.90.0",
     "minecraft": ">=1.20.1",
     "java": ">=17",
     "revelationary": "*",


### PR DESCRIPTION
Makes Spectrum work for Quilt 1.20.1. Just some minor things that need changing to get it working. One of them is to downgrade the dependency requirement but it's by one minor version and doesn't impact the mod at all.

- Downgrade dependency requirements (Quilt hasn't updated yet :/). The newer FAPI stuff wasn't used anyway so it's fine :3.
- Fix Criteria accessor issues. See https://github.com/DaFuqs/Revelationary/issues/9 for more details.