### PR TITLE
Jade Vine Petal Block > Jade Vine Petals

### DIFF
--- a/src/main/resources/data/spectrum/recipes/pedestal/tier1/jade_vines/jade_petals_from_petal_block.json
+++ b/src/main/resources/data/spectrum/recipes/pedestal/tier1/jade_vines/jade_petals_from_petal_block.json
@@ -1,0 +1,25 @@
+{
+  "type": "spectrum:pedestal",
+  "group": "jade_decorations",
+  "time": 40,
+  "tier": "basic",
+  "cyan": 0,
+  "magenta": 0,
+  "yellow": 0,
+  "white": 0,
+  "black": 0,
+  "experience": 0.0,
+  "pattern": [
+    "X"
+  ],
+  "key": {
+    "X": {
+      "item": "spectrum:jade_vine_petal_block"
+    }
+  },
+  "result": {
+    "item": "spectrum:jade_vine_petals",
+    "count": 4
+  },
+  "required_advancement": "spectrum:hidden/collect_jade_vine_petals"
+}

--- a/src/main/resources/data/spectrum/recipes/pedestal/tier1/jade_vines/jade_petals_from_petal_block.json
+++ b/src/main/resources/data/spectrum/recipes/pedestal/tier1/jade_vines/jade_petals_from_petal_block.json
@@ -1,5 +1,5 @@
 {
-  "type": "spectrum:pedestal",
+  "type": "spectrum:pedestal_shapeless",
   "group": "jade_decorations",
   "time": 40,
   "tier": "basic",
@@ -9,17 +9,15 @@
   "white": 0,
   "black": 0,
   "experience": 0.0,
-  "pattern": [
-    "X"
-  ],
-  "key": {
-    "X": {
+  "ingredients": [
+    {
       "item": "spectrum:jade_vine_petal_block"
     }
-  },
+  ],
   "result": {
     "item": "spectrum:jade_vine_petals",
     "count": 4
   },
-  "required_advancement": "spectrum:hidden/collect_jade_vine_petals"
+  "required_advancement": "spectrum:hidden/collect_jade_vine_petals",
+  "disable_yield_upgrades": true
 }


### PR DESCRIPTION
Added a recipe for turning Jade Vine Petal Blocks back into Jade Vine Petals, as Effulgent Feathers (which has a similar set of blocks) has a recipe to reclaim the raw material from the block.