### PR TITLE
Guidebook grammar and clarification

### DIFF
--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/brewing/frenzy.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/brewing/frenzy.json
@@ -8,12 +8,12 @@
     {
       "type": "spectrum:status_effect",
       "status_effect_id": "spectrum:frenzy",
-      "text": "Damage, attack speed, movement speed and knockback resistance are buffed with each kill. The higher the effects level, the higher the buff. Not scoring a kill in 10 seconds will debuff you instead."
+      "text": "Damage, attack speed, movement speed and knockback resistance are buffed with each kill. The higher the effect's level, the higher the buff. Not scoring a kill in 10 seconds will debuff you instead."
     },
     {
       "type": "patchouli:text",
       "title": "Stacking Effect",
-      "text": "Getting a level of Frenzy will instead stack additional Levels on top of existing ones, increasing the effects Potency instead of resetting it's duration."
+      "text": "Getting a level of Frenzy will instead stack additional Levels on top of existing ones, increasing the effect's Potency instead of resetting its duration."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/brewing/potion_workshop.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/brewing/potion_workshop.json
@@ -16,7 +16,7 @@
       "type": "spectrum:pedestal_crafting",
       "title": "Pedestal Recipe",
       "recipe": "spectrum:pedestal/tier3/potion_workshop",
-      "text": "Instead of $(item)Blaze Powder$(), the Potion Workshop runs on $(l:resources/mermaids_brush)Mermaid's Gems$(). Main advantage is that you don't have to fill your bottles with water before."
+      "text": "Instead of $(item)Blaze Powder$(), the Potion Workshop runs on $(l:resources/mermaids_brush)Mermaid's Gems$(). The main advantage is that you don't have to fill your bottles with water before."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/brewing/potion_workshop_crafting.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/brewing/potion_workshop_crafting.json
@@ -16,7 +16,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "As the name implies the $(l:brewing/potion_workshop)Potion Workshop's$() main focus is the creation of powerful $(item)Potions$().$(br)But with the help of all of the filigree and granular adjustable switches and valves you found great utility in it for creating other things, too.$(br)$()All these recipes do not use $(l:brewing/potion_workshop_reagents)Reagents$(/l)."
+      "text": "As the name implies, the $(l:brewing/potion_workshop)Potion Workshop's$() main focus is the creation of powerful $(item)Potions$().$(br)But with the help of all of the filigree and granular adjustable switches and valves you found great utility in it for creating other things, too.$(br)$()All these recipes do not use $(l:brewing/potion_workshop_reagents)Reagents$(/l)."
     },
     {
       "type": "spectrum:potion_workshop_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/brewing/potion_workshop_reagents.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/brewing/potion_workshop_reagents.json
@@ -62,7 +62,7 @@
       "type": "patchouli:spotlight",
       "item": "spectrum:moonstone_powder",
       "advancement": "spectrum:lategame/collect_moonstone_shard",
-      "text": "$(li)converts negative effects to their positive ones"
+      "text": "$(li)converts negative effects to equivalent positive ones"
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/creating_life/egg_laying_wooly_pig.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/creating_life/egg_laying_wooly_pig.json
@@ -11,7 +11,7 @@
     {
       "type": "patchouli:text",
       "title": "Egg Laying Wooly Pig",
-      "text": "Your whole \"creating life\" thing has worked rather mixed so far. But slowly you feel you are able to move something.$(br2)Creating life from nothing is a difficult thing, but combining existing knowledge? You feel a bit like Frankenstein himself.$(br)$(italic)Is that a good thing? Bad? You are not sure at all."
+      "text": "Your whole \"creating life\" thing has yielded mixed results so far. But slowly you feel you are able to move something.$(br2)Creating life from nothing is a difficult thing, but combining existing knowledge? You feel a bit like Frankenstein himself.$(br)$(italic)Is that a good thing? Bad? You are not sure at all."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/creating_life/fading.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/creating_life/fading.json
@@ -12,7 +12,7 @@
     {
       "type": "patchouli:spotlight",
       "item": "spectrum:bottle_of_fading",
-      "text": "It did not take long, there the idea for a construction plan came to you.$(br2)The organism you came up with is weak, but it seems that your plans to create new life were successful, at least in principle! Admittedly, it is only a clump of microorganisms, but they are alive!"
+      "text": "It did not take long before the idea for a construction plan came to you.$(br2)The organism you came up with is weak, but it seems that your plans to create new life were successful, at least in principle! Admittedly, it is only a clump of microorganisms, but they are alive!"
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/creating_life/mob_heads.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/creating_life/mob_heads.json
@@ -8,7 +8,7 @@
     {
       "type": "patchouli:text",
       "title": "Mob Heads",
-      "text": "Using your new $(l:enchanting/treasure_hunter)Treasure Hunter$(/l) enchantment you are able to collect heads from all kinds of mobs.$(br2)While they make for a nice display of your modest acquisitions they still inherit a small spark of that creatures existence."
+      "text": "Using your new $(l:enchanting/treasure_hunter)Treasure Hunter$(/l) enchantment you are able to collect heads from all kinds of mobs.$(br2)While they make for a nice display of your modest acquisitions they still inherit a small spark of that creature's existence."
     },
     {
       "type": "spectrum:collection",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/creating_life/spirit_instiller.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/creating_life/spirit_instiller.json
@@ -9,20 +9,20 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Created with all the knowledge you have gathered, you have created the Spirit Instiller. It serves to be able to connect the energies of two items, with the help of a third object to bind them.$(br2)An almost spiritual process."
+      "text": "With all the knowledge you have gathered, you have created the Spirit Instiller. It seems to be able to connect the energies of two items, with the help of a third object to bind them.$(br2)An almost spiritual process."
     },
     {
       "type": "spectrum:pedestal_crafting",
       "title": "Pedestal Recipe",
       "recipe": "spectrum:pedestal/tier3/spirit_instiller",
-      "text": "The Spirit Instiller needs a focus structure to work. To rotate the structure hologram in the direction you want it to, click on the placed Spirit Instiller itself."
+      "text": "The Spirit Instiller needs a focus structure to work. To rotate the structure hologram in the direction you want, click on the placed Spirit Instiller itself."
     },
     {
       "type": "patchouli:multiblock",
       "name": "Instiller Structure",
       "multiblock_id": "spectrum:spirit_instiller_structure",
       "enable_visualize": true,
-      "text": "Dimensions: 8x9x5 blocks$(br)It can be enhanced using $(l:magical_blocks/upgrades)Upgrades$() by placing them on the two $(item)Onyx Chiseled Blocks$()."
+      "text": "Dimensions: 8x9x5 blocks$(br)It can be enhanced by placing $(l:magical_blocks/upgrades)Upgrades$() on the two $(item)Onyx Chiseled Blocks$()."
     },
     {
       "type": "patchouli:text",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/blood_orchid_products.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/blood_orchid_products.json
@@ -13,36 +13,36 @@
       "type": "patchouli:spotlight",
       "title": "Blood Orchid Products",
       "item": "spectrum:bloodboil_syrup",
-      "text": "Extracts of the $(l:resources/blood_orchid)Blood Orchid$(/l) have an intense effect when consumed: they may put you in a $(thing)Frenzy$().$(br)Damage, attack speed, movement speed and knockback resistance are buffed with each kill. The higher the effects level, the higher the buff. Not scoring a kill in 10 seconds will debuff you instead."
+      "text": "Extracts of the $(l:resources/blood_orchid)Blood Orchid$(/l) have an intense effect when consumed: they may put you in a $(thing)Frenzy$().$(br)Damage, attack speed, movement speed and knockback resistance are buffed with each kill. The higher the effect's level, the higher the buff. Not scoring a kill in 10 seconds will debuff you instead."
     },
     {
       "type": "patchouli:text",
       "title": "Frenzy Stacking",
-      "text": "Instead of resetting the duration, applying another $(thing)Frenzy$() effect will increase its potency instead.$(br2)In order to get the most out of the effect apply one with a long duration first, then stack up seems to be most effective."
+      "text": "Instead of resetting the duration, applying another $(thing)Frenzy$() effect will increase its potency instead.$(br2)In order to get the most out of the effect, apply one with a long duration first, then stack up with shorter effects."
     },
     {
       "type": "spectrum:potion_workshop_crafting",
       "recipe": "spectrum:potion_workshop_crafting/bloodboil_syrup",
-      "text": "A Petals active ingredient can be extracted into a thick solution. Almost smells like rose water, but its effect is definitely... $(italic)a little more effervescent$()."
+      "text": "A Petal's active ingredient can be extracted into a thick solution. Almost smells like rose water, but its effect is definitely... $(italic)a little more effervescent$()."
     },
     {
       "type": "spectrum:pedestal_crafting",
       "advancement": "spectrum:unlocks/food/demon_trifle",
       "recipe": "spectrum:pedestal/tier1/food/demon_trifle",
-      "text": "The $(thing)Frenzy$() effect you may get is starts out low, but lasts a bit longer."
+      "text": "The $(thing)Frenzy$() effect you may get starts out low, but lasts a bit longer."
     },
     {
       "type": "spectrum:potion_workshop_crafting",
       "advancement": "spectrum:unlocks/food/demon_tea",
       "recipe": "spectrum:potion_workshop_crafting/demon_tea",
-      "text": "The $(thing)Frenzy$() effect you may get is relatively short, but starts out quite high."
+      "text": "The $(thing)Frenzy$() effect you may get is relatively short, but starts out quite potent."
     },
     {
       "type": "spectrum:titration_barrel_fermenting",
       "advancement": "spectrum:unlocks/food/rabbit_poison",
       "title": "Rabbit Poison",
       "recipe": "spectrum:titration_barrel/infused_beverages/rabbit_poison",
-      "text": "A truly nasty brew. Tastes exactly what you would expect."
+      "text": "A truly nasty brew. Tastes exactly like what you would expect."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/brewers_handbook.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/brewers_handbook.json
@@ -22,7 +22,7 @@
     },
     {
       "type": "patchouli:text",
-      "text": "Hayo! The current state of relations between the overworld and the deep is rather poor, and unfortunately it seems to only be getting worse, and to that end I sadly can't do much.$(br2)As such, I have taking some of my time to collect a bunch of brewing recipes from the surface, adapt them to use ingredients found in the depths, and publish that as a gift to you all, in hopes that it will aid you."
+      "text": "Hayo! The current state of relations between the overworld and the deep is rather poor, and unfortunately it seems to only be getting worse, and to that end I sadly can't do much.$(br2)As such, I have taken some of my time to collect a bunch of brewing recipes from the surface, adapt them to use ingredients found in the depths, and publish that as a gift to you all, in hopes that it will aid you."
     },
     {
       "type": "patchouli:text",
@@ -85,7 +85,7 @@
     {
       "type": "spectrum:potion_workshop_crafting",
       "recipe": "spectrum:potion_workshop_crafting/sedatives",
-      "text": "$(italic)This took a lot out of me to get working. Through this, you should be able to use blood orchid extras more aggressively. If worse comes to worst, it should give you an edge."
+      "text": "$(italic)This took a lot out of me to get working. Through this, you should be able to use blood orchid extract more aggressively. If worse comes to worst, it should give you an edge."
     },
     {
       "type": "patchouli:text",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/glistering_jelly_tea.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/glistering_jelly_tea.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "The $(l:resources/jade_vines)Jade Vine$() is known for its regenerative properties, similar to $(item)Glistering Melons$(). As it happens, mixed together unfolds exquisitely harmonious, sweet taste.$(br2)Temporarily grants you a small health boost."
+      "text": "The $(l:resources/jade_vines)Jade Vine$() is known for its regenerative properties, similar to $(item)Glistering Melons$(). As it happens, mixing them together reveals an exquisitely harmonious, sweet taste.$(br2)Temporarily grants you a small health boost."
     },
     {
       "type": "spectrum:potion_workshop_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/imbrifer_cookbook.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/imbrifer_cookbook.json
@@ -27,7 +27,7 @@
     {
       "type": "patchouli:text",
       "title": "A Simple Entree",
-      "text": "$(br)Everybody has to start somewhere, and for my students, this is that somewhere. Crawfish Cocktails are deceiving, they seem simple, but to truly master them takes finesse and practice. It is possible to flambe the peaches and spices to make a sweet, syrupy, spicy sauce without cooking the crawfish, but it demands an immense amount of care. I use this to filter new students."
+      "text": "$(br)Everybody has to start somewhere, and for my students, this is that somewhere. Crawfish Cocktails are deceiving, they seem simple, but to truly master them takes finesse and practice. It is possible to flambé the peaches and spices to make a sweet, syrupy, spicy sauce without cooking the crawfish, but it demands an immense amount of care. I use this to filter new students."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/imperial_cookbook.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/imperial_cookbook.json
@@ -57,7 +57,7 @@
     {
       "type": "patchouli:text",
       "title": "Lotus of the Sea",
-      "text": "$(br)I have a fun story tied to this recipe. Koi, past being gorgeous creatures, make for the basis of some of the most unique and stunning imperial recipes. These recipes however often require odd and exotic ingredients, and one day we were clean out the night before a banquet. Thinking swiftly, I swapped out the ferment for $(l:creating_life/fading)mother of moor$(), resulting in this flower-like dish."
+      "text": "$(br)I have a fun story tied to this recipe. Koi, in addition to being gorgeous creatures, make for the basis of some of the most unique and stunning imperial recipes. These recipes however often require odd and exotic ingredients, and one day we were clean out the night before a banquet. Thinking swiftly, I swapped out the ferment for $(l:creating_life/fading)mother of moor$(), resulting in this flower-like dish."
     },
     {
       "type": "spectrum:titration_barrel_fermenting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/infused_beverages.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/infused_beverages.json
@@ -50,7 +50,7 @@
       "title": "Beers",
       "recipe": "spectrum:titration_barrel/infused_beverages/beer",
       "recipe2": "spectrum:titration_barrel/infused_beverages/ale",
-      "text": "Additionally to Haste it can grant a bit of Saturation, depending on the time it fermented."
+      "text": "In addition to Haste it can grant a bit of Saturation, depending on how long it fermented."
     },
     {
       "type": "spectrum:titration_barrel_fermenting",
@@ -72,7 +72,7 @@
       "advancement": "spectrum:milestones/confirmed_drinking_age",
       "title": "Rum",
       "recipe": "spectrum:titration_barrel/infused_beverages/rum",
-      "text": "Strong to the taste, made even more intense via the influence of the colored wood, grants $(thing)Absorption$() and $(thing)Resistance$()."
+      "text": "A strong taste, made even more intense via the influence of the colored wood, grants $(thing)Absorption$() and $(thing)Resistance$()."
     },
     {
       "type": "spectrum:titration_barrel_fermenting",
@@ -143,7 +143,7 @@
       "title": "Vodka",
       "recipe": "spectrum:titration_barrel/infused_beverages/vodka",
       "recipe2": "spectrum:titration_barrel/infused_beverages/poisonous_vodka",
-      "text": "Gets only stronger with age. Just one question: How deadly do you want it?"
+      "text": "Only gets stronger with age. Just one question: How deadly do you want it?"
     },
     {
       "type": "spectrum:titration_barrel_fermenting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/jade_wine.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/jade_wine.json
@@ -10,7 +10,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Since the $(l:resources/jade_vines)Jade Vines$() are notorious for restorative properties, no wonder these translate perfectly when fermented.$(br)In contrast to the slight bitterness of the bulbs, adding a good share of petals brings out a more bloomy and slightly sour taste instead, complimented with earthy undertones - almost resembling wine, in trademark jade color."
+      "text": "Since the $(l:resources/jade_vines)Jade Vines$() are notorious for restorative properties, it's no wonder they translate perfectly when fermented.$(br)In contrast to the slight bitterness of the bulbs, adding a good share of petals brings out a more bloomy and slightly sour taste instead, complimented with earthy undertones - almost resembling wine, in trademark jade color."
     },
     {
       "type": "spectrum:titration_barrel_fermenting",
@@ -24,7 +24,7 @@
       "advancement": "spectrum:midgame/tap_sweetened_jade_wine",
       "anchor": "sweetened_jade_wine",
       "item": "spectrum:moonstruck_nectar",
-      "text": "Adding a drop of $(item)Moonstruck Nectar$() seems to make the Wine much more easy to drink. Both the fermentation process is increased and negative effects softened noticeably."
+      "text": "Adding a drop of $(item)Moonstruck Nectar$() seems to make the Wine much easier to drink. The fermentation process is increased and negative effects are noticeably softened."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/melochites_cookbook_vol_1.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/melochites_cookbook_vol_1.json
@@ -37,7 +37,7 @@
     {
       "type": "patchouli:text",
       "title": "Hearty Roast with Beer",
-      "text": "$(br)Young hare is a delicacy not just here in Melochites, but in most of any place where Dreitons roam. If you get the chance, please, $(o)please$() try using an artisanal azurte stout in this recipe, that kind of beer is only made in a sparse few areas of Melochites but trust me, hard as it may be to get, it is life changing with rabbit."
+      "text": "$(br)Young hare is a delicacy not just here in Melochites, but in almost any place where Dreitons roam. If you get the chance, please, $(o)please$() try using an artisanal azurte stout in this recipe, that kind of beer is only made in a sparse few areas of Melochites but trust me, hard as it may be to get, it is life changing with rabbit."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/reprise.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/reprise.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "This beverage, brewed from $(item)Chorus Fruit$(), takes over - and amplifies - not only the special taste, but also the unique property of the plant.$(br2)When ingested, this drink randomly teleports you over great distances. The higher the alcohol content, the further."
+      "text": "This beverage, brewed from $(item)Chorus Fruit$(), inherits - and amplifies - not only the special taste, but also the unique property of the plant.$(br2)When ingested, this drink randomly teleports you over great distances. The higher the alcohol content, the further."
     },
     {
       "type": "spectrum:titration_barrel_fermenting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/restoration_tea.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/restoration_tea.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Is there anything cozier than sitting by your homemade fireplace on a rainy evening, sipping a cup of tea?$(br)Surely: killing a boss beforehand.$(br2)This tea, brewed from the petals of $(l:resources/jade_vines)Jade Vines$(/l) is both good for relaxing and protecting you from the deadly effect of the Wither. $(italic)Convenient$()."
+      "text": "Is there anything cozier than sitting by your homemade fireplace on a rainy evening, sipping a cup of tea?$(br)Surely: killing a boss beforehand.$(br2)This tea, brewed from the petals of $(l:resources/jade_vines)Jade Vines$(/l) is good for both relaxing and protecting you from the deadly effect of the Wither. $(italic)Convenient$()."
     },
     {
       "type": "spectrum:potion_workshop_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/sawblade_holly.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/sawblade_holly.json
@@ -12,7 +12,7 @@
     {
       "type": "patchouli:spotlight",
       "item": "spectrum:sawblade_holly_berry",
-      "text": "These berries remind you of $(item)Sweetberries$(). In contrast to those, however, these are much drier.$(br)Can be eaten, but have an unpleasant consistency. Better than nothing, should things get tough."
+      "text": "These berries remind you of $(item)Sweetberries$(). In contrast to those, however, these are rather dry.$(br)Can be eaten, but have an unpleasant consistency. Better than nothing, should things get tough."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/star_candy.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/star_candy.json
@@ -10,7 +10,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "It seems those $(l:resources/stargazing)Shooting Stars$(/l) have more secrets than you previously thought, and weird ones at that.$(br)Baked $(l:resources/stargazing#stardust)Stardust$() tastes oddly refreshing, the magic makes your tongue tingle as the heaven-sent candy dissolves in your mouth. You felt an odd lot healthier afterwards.$(br)Their hard, golden flesh has some purple speckles, shimmering like star shards."
+      "text": "It seems those $(l:resources/stargazing)Shooting Stars$(/l) have more secrets than you previously thought, and weird ones at that.$(br)Baked $(l:resources/stargazing#stardust)Stardust$() tastes oddly refreshing, the magic makes your tongue tingle as the heaven-sent candy dissolves in your mouth. You felt strangely healthier afterwards.$(br)Their hard, golden flesh has some purple speckles, shimmering like star shards."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/tarts.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/tarts.json
@@ -31,7 +31,7 @@
     {
       "type": "spectrum:pedestal_crafting",
       "recipe": "spectrum:pedestal/tier1/food/ashen_tart",
-      "text": "Makes you able to see & swim in Lava as were it Water.$(br)However, does NOT make you fire immune."
+      "text": "Makes you able to see & swim in Lava as if it were Water.$(br)However, does NOT make you fire immune."
     },
     {
       "type": "spectrum:pedestal_crafting",
@@ -41,7 +41,7 @@
     {
       "type": "spectrum:pedestal_crafting",
       "recipe": "spectrum:pedestal/tier1/food/whispy_tart",
-      "text": "Makes you feel well rested, like after a good nights sleep. Scares away creatures of nightmares."
+      "text": "Makes you feel well rested, like after a good night's sleep. Scares away creatures of nightmares."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/titration_barrel.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/titration_barrel.json
@@ -14,7 +14,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "The idea of fermenting $(l:cuisine/titration_barrel#kimchi)food$(/l) and $(l:cuisine/infused_beverages)drinks$(/l) in $(l:general/colored_trees#colored_wood)Colored Wood$(/l) was not far away. Over time, the properties of the wood influences its contents.$(br)The results are sometimes more, sometimes less delicious, but always interesting. (On the other hand, the latter could of course also be due to your cooking skills.)$(br)Holds up to a stack of items and 1 bucket of liquid."
+      "text": "The idea of fermenting $(l:cuisine/titration_barrel#kimchi)food$(/l) and $(l:cuisine/infused_beverages)drinks$(/l) in $(l:general/colored_trees#colored_wood)Colored Wood$(/l) was not far away. Over time, the properties of the wood influence its contents.$(br)The results are sometimes more and sometimes less delicious (although the latter could be due to your cooking skills), but always interesting.$(br)Holds up to a stack of items and 1 bucket of liquid."
     },
     {
       "type": "spectrum:pedestal_crafting",
@@ -33,7 +33,7 @@
       "type": "spectrum:titration_barrel_fermenting",
       "anchor": "fermented_spider_eyes",
       "recipe": "spectrum:titration_barrel/fermented_spider_eyes",
-      "text": "Takes a short while, but more efficient than just slapping those together."
+      "text": "Takes a short while, but more efficient than just slapping the ingredients together."
     },
     {
       "type": "spectrum:titration_barrel_fermenting",
@@ -70,7 +70,7 @@
       "advancement": "spectrum:unlocks/blocks/potion_workshop",
       "anchor": "hot_chocolate",
       "recipe": "spectrum:potion_workshop_crafting/hot_chocolate",
-      "text": "Perfect to come to the calm and in the cold season."
+      "text": "Perfect for relaxing, and refreshing in the cold season."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/trifles.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/cuisine/trifles.json
@@ -11,7 +11,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Sweet delicacies, guaranteed to not only give you a sugar rush - depending on the toppings.$(br)Made from $(l:resources/jade_vines#jaramel)Jaramel$(/l), $(thing)Gelatin$() & $(l:cuisine/amaranth)Amaranth$(/l).$(br)Even the simple one tastes great!"
+      "text": "Sweet delicacies, guaranteed to give you more than a sugar rush - depending on the toppings.$(br)Made from $(l:resources/jade_vines#jaramel)Jaramel$(/l), $(thing)Gelatin$() & $(l:cuisine/amaranth)Amaranth$(/l).$(br)Even the simple one tastes great!"
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/block_variants.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/block_variants.json
@@ -20,7 +20,7 @@
         "spectrum:smooth_basalt_wall",
         "spectrum:calcite_wall"
       ],
-      "text": "The bright white of Calcite may be the brightest natural color you've stumbled across, very clean looking and radiating dignity. The white Calcite is a wonderful contrast to the dark hues of Basalt."
+      "text": "The bright white of Calcite may be the brightest natural color you've stumbled across - very clean looking and radiating dignity. A wonderful contrast to the dark hues of Basalt."
     },
     {
       "type": "patchouli:smelting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/block_variants.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/block_variants.json
@@ -20,7 +20,7 @@
         "spectrum:smooth_basalt_wall",
         "spectrum:calcite_wall"
       ],
-      "text": "The bright white of Calcite may be the brightest natural color you've stumbled across, looking very clean and radiating dignity. The white Calcite is a wonderful contrast to the dark hues of Basalt."
+      "text": "The bright white of Calcite may be the brightest natural color you've stumbled across, very clean looking and radiating dignity. The white Calcite is a wonderful contrast to the dark hues of Basalt."
     },
     {
       "type": "patchouli:smelting",
@@ -28,7 +28,7 @@
       "title": "Polishing",
       "recipe": "spectrum:smelting/smooth_basalt_to_polished_basalt",
       "recipe2": "spectrum:smelting/calcite_to_polished_calcite",
-      "text": "Applying heat emphasizes their dark and white textures even more.$(br)When smelted, the Basalt almost turns black. They can be crafted into a wide array of decoration blocks in the $(item)Crafting Table$() or $(item)Stone Cutter$()."
+      "text": "Applying heat emphasizes their dark and white textures even more.$(br)When smelted, the Basalt turns nearly black. They can be crafted into a wide array of decoration blocks in the $(item)Crafting Table$() or $(item)Stone Cutter$()."
     },
     {
       "type": "spectrum:collection",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/gemstone_lamps.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/gemstone_lamps.json
@@ -20,7 +20,7 @@
       "type": "patchouli:spotlight",
       "item": "spectrum:citrine_basalt_lamp",
       "title": "Gemstone Lamps",
-      "text": "When you set foot in the first geode, you were met with pleasant cozy glow. With your knowledge and the help of Shimmerstone, it is easy to amplify this light to create fancy lamps.$()"
+      "text": "When you set foot in the first geode, you were met with a pleasant cozy glow. With your knowledge and the help of Shimmerstone, it is easy to amplify this light to create fancy lamps.$()"
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/gemstone_runes.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/gemstone_runes.json
@@ -30,7 +30,7 @@
       "type": "spectrum:pedestal_crafting",
       "title": "Alternative Recipe",
       "recipe": "spectrum:pedestal/tier1/runes/amethyst_chiseled_basalt_from_cluster",
-      "text": "If you manage to get a hold of complete gemstone clusters, the runes are much more efficient to create."
+      "text": "If you manage to obtain complete gemstone clusters, the runes are much more efficient to create."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/item_roundel.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/item_roundel.json
@@ -10,7 +10,7 @@
     {
       "type": "patchouli:text",
       "item": "spectrum:item_roundel",
-      "text": "You very much took a liking to the rotating roundels in those ancient structures, so much that you copied their design yourself. Definitely a nice way to present your items, or keep them ready.$(br2)$(italic)Hopefully the patents have already expired."
+      "text": "You immediately took a liking to the rotating roundels in those ancient structures, so much so that you copied their design yourself. Definitely a nice way to present your items, or keep them ready.$(br2)$(italic)Hopefully the patents have already expired."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/particle_spawner.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/particle_spawner.json
@@ -10,7 +10,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "The $(l:resources/stargazing)Shooting Star$() you picked up left a fantastic shower of particles on their way to the ground. You created the Particle Spawner to replicate this spectacle - and lots of others - yourself.$()$(br2)A chimney? Rocket launching particles? Atmospheric particle rain for your Pedestal? The Particle Spawner got you covered."
+      "text": "The $(l:resources/stargazing)Shooting Star$() you picked up left a fantastic shower of particles on their way to the ground. You created the Particle Spawner to replicate this spectacle - and lots of others - yourself.$()$(br2)A chimney? Rocket launching particles? Atmospheric particle rain for your Pedestal? The Particle Spawner has you covered."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/crystal_gardens.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/crystal_gardens.json
@@ -18,9 +18,7 @@
     {
       "type": "patchouli:image",
       "title": "Crystal Gardens",
-      "images": [
-        "spectrum:textures/gui/guidebook/dd_crystal_gardens.png"
-      ],
+      "images": ["spectrum:textures/gui/guidebook/dd_crystal_gardens.png"],
       "border": true,
       "text": "Lakes of $(l:magical_blocks/liquid_crystal)Liquid Crystal$() and giant $(l:dimension/hummingstone)crystalline structures$() define its look."
     },
@@ -33,7 +31,7 @@
       "type": "patchouli:text",
       "title": "Nephrite Blossoms",
       "advancement": "spectrum:hidden/collect_glass_peach",
-      "text": "Little trees, as big as they get down here - more like a big bush. ...or giant shrub.$(br)Eeeeh, details.$(br2)Their fruit isn't made of glass, but it shimmers very much like it would be. They are very tasty too.$(br)Eating one will give you a short burst of $(thing)Toughness$(), which reduces the damage you take from hard attacks. They can also be $(l:cuisine/infused_beverages)fermented$() and $(l:brewing/potion_workshop_brewing)used to brew potions$()."
+      "text": "Little trees, as big as they get down here - more like a big bush. ...or giant shrub.$(br)Eeeeh, details.$(br2)Their fruit isn't made of glass, but it shimmers very much as if it is. They are very tasty too.$(br)Eating one will give you a short burst of $(thing)Toughness$(), which reduces the damage you take from hard attacks. They can also be $(l:cuisine/infused_beverages)fermented$() and $(l:brewing/potion_workshop_brewing)used to brew potions$()."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/doomblooms.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/doomblooms.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "This plant has a rather... unusual way to dispense its seed and scare away predators: Its blossom houses a capsule of explosive gas that pops, when disturbed. When not being cautious around this flower, be it touching it a bit too harshly, you risk converting your surroundings into a burning crater."
+      "text": "This plant has a rather... unusual way to dispense its seed and scare away predators: Its blossom houses a capsule of explosive gas that pops, when disturbed. When not being cautious around this flower, such as touching it a bit too harshly, you risk converting your surroundings into a burning crater."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/downstone.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/downstone.json
@@ -18,7 +18,7 @@
       "item": "spectrum:downstone_fragments",
       "anchor": "downstone_fragments",
       "advancement": "spectrum:lategame/collect_downstone_fragments",
-      "text": "Looks like whoever came before you was able to harvest it - however only using colossal, imposing drills.$(br2)It seems like they used it to manufacture $(item)Preservation Stone$()?"
+      "text": "Looks like whoever came before you was able to harvest it - but only with the help of colossal, imposing drills.$(br2)It seems like they used it to manufacture $(item)Preservation Stone$()?"
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/dragonbone.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/dragonbone.json
@@ -35,14 +35,14 @@
       "advancement": "spectrum:lategame/break_cracked_dragonbone",
       "anchor": "dragonbone_chunks",
       "item": "spectrum:dragonbone_chunk",
-      "text": "Damaging Dragonbone using $(thing)Explosions$() seems to breeze away most of the magical protective aura, making you able to finally mine it.$(br)The dropped pieces still retained some of that ancient, magical aura."
+      "text": "Damaging Dragonbone using $(thing)Explosions$() seems to breeze away most of the magical protective aura, finally making it mineable.$(br)The dropped pieces still retained some of that ancient, magical aura."
     },
     {
       "type": "spectrum:cinderhearth_smelting",
       "title": "Turning to Ash",
       "advancement": "spectrum:lategame/break_cracked_dragonbone",
       "recipe": "spectrum:cinderhearth/bone_ash",
-      "text": "The $(l:magical_blocks/cinderhearth)Cinderhearth$() is the only thing that generates heat hot enough to turn these bones into ash."
+      "text": "The $(l:magical_blocks/cinderhearth)Cinderhearth$() is the only thing that generates enough heat to turn these bones into ash."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/dragonrot_swamp.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/dimension/dragonrot_swamp.json
@@ -11,11 +11,9 @@
     {
       "type": "patchouli:image",
       "title": "Dragonrot Swamp",
-      "images": [
-        "spectrum:textures/gui/guidebook/dd_dragonrot_swamp.png"
-      ],
+      "images": ["spectrum:textures/gui/guidebook/dd_dragonrot_swamp.png"],
       "border": true,
-      "text": "Lakes of $(l:dimension/dragonrot)Dragonrot$(/l) pervades the swamp-like thicket here.$(br)An acidic smell lingers in the air."
+      "text": "Lakes of $(l:dimension/dragonrot)Dragonrot$(/l) pervade the swamp-like thicket here.$(br)An acidic smell lingers in the air."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/big_catch.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/big_catch.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Your new magic fishing rods have the interesting property of attracting even living creatures. Why that wasn't a thing with your boring rods? I don't know.$(br)With this enchantment, you can further increase the chance of catching living creatures."
+      "text": "Your new magic fishing rods have the interesting property of attracting even living creatures. Why wasn't that a thing with your boring rods? I don't know.$(br)With this enchantment, you can further increase the chance of catching living creatures."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/clovers_favor.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/clovers_favor.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Every now and then you are lucky enough to have an enemy leave behind a single rare item.$(br)The connection of $(l:resources/clover)Clovers$(/l) and $(l:general/pigment#light_blue)Light Blue Pigment$(/l) to luck you can increase those chances dramatically."
+      "text": "Every now and then you are lucky enough to have an enemy leave behind a single rare item.$(br)The connection of $(l:resources/clover)Clovers$(/l) and $(l:general/pigment#light_blue)Light Blue Pigment$(/l) to luck allows you to increase those chances dramatically."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/curse_of_the_void.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/curse_of_the_void.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Your tools with this enchantment seem to dissolve all things they mine into thin air. Broken down into the finest sand and blown away by the wind.$(br2)For this one time, however, when you want to knock half a city out of rough stone, it might even come in handy. Some things are probably curse and blessing at the same time."
+      "text": "Your tools with this enchantment seem to dissolve all things they mine into thin air. Broken down into the finest sand and blown away by the wind.$(br2)When you want to knock half a city out of rough stone, it might even come in handy. Some things are probably a curse and a blessing at the same time."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/disarming.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/disarming.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "The Zombies you encounter every day wear lots of valuable equipment. But when they die, it disappears never to be seen again.$(br2)No problem if you manage to snatch it from them while they are still alive. Gotcha!"
+      "text": "The Zombies you encounter every night wear lots of valuable equipment. But when they die, it disappears never to be seen again.$(br2)No problem if you manage to snatch it from them while they are still alive. Gotcha!"
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/enchanter.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/enchanter.json
@@ -21,7 +21,7 @@
       "name": "Enchanting Structure",
       "multiblock_id": "spectrum:enchanter_structure",
       "enable_visualize": true,
-      "text": "Dimensions: 11x11x5 blocks$(br)Can be enhanced using $(l:magical_blocks/upgrades)Upgrades$() by placing them on the four Gemstone Blocks."
+      "text": "Dimensions: 11x11x5 blocks$(br)Can be enhanced by placing $(l:magical_blocks/upgrades)Upgrades$() on the four Gemstone Blocks."
     },
     {
       "type": "patchouli:text",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/exuberance.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/exuberance.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "That fancy book table of yours, while useful, more or less swallows every piece of experience, as soon as you acquire it. To satisfy its never diminishing hunger to supply your ever-growing list of enchanted tools.$(br2)Squeezing the last bit of experience out of your opponents will help a lot."
+      "text": "That fancy book table of yours, while useful, more or less swallows every piece of experience as soon as you acquire it. Satisfying its never diminishing hunger to supply your ever-growing list of enchanted tools is a monumental task.$(br2)Squeezing the last bit of experience out of your opponents will help a lot."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/gilded_book.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/gilded_book.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Gilded books serve as an alternative to mundane Books for enchanting in the $(l:enchanting/enchanter)Enchanter$(/l). Being much more receptive for magic, the enchanting process will be both faster and cheaper.$(br)More than that, they can even be used to copy enchantments from all kinds of Items in the Item Bowls around the Enchanter onto itself (not just from other Enchanted Books)."
+      "text": "Gilded books serve as an alternative to mundane Books for enchanting in the $(l:enchanting/enchanter)Enchanter$(/l). Being much more receptive for magic, the enchanting process will be both faster and cheaper.$(br)They can even be used to copy enchantments from all kinds of Items in the Item Bowls around the Enchanter onto itself (not just from other Enchanted Books)."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/improved_critical.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/improved_critical.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You already noticed that you deal significantly more damage to enemies if you jump while attacking.$(br)To further improve those jump attacks, you have developed this enhancement, which increases the additional damage even more."
+      "text": "You already noticed that you deal significantly more damage to enemies if you jump while attacking.$(br)To further improve those jump attacks, you have developed this enchantment, which increases the additional damage even more."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/improved_critical.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/improved_critical.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You already noticed dealing significantly more damage to enemies if you jump while attacking.$(br)To further improve those jump attacks, you have developed this enhancement, which increases the additional damage even more."
+      "text": "You already noticed that you deal significantly more damage to enemies if you jump while attacking.$(br)To further improve those jump attacks, you have developed this enhancement, which increases the additional damage even more."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/indestructible.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/indestructible.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You've come this far and you still have to deal with the fact that your common tools like $(item)Flint and Steel$() keep breaking once you use it too many times. And you had more than enough equipment, which was previously too fragile to use for long.$(br)With your full armada of nearly-indestructible items now, though? No problem."
+      "text": "You've come this far and you still have to deal with the fact that your common tools like $(item)Flint and Steel$() keep breaking once you use them too many times. And you have more than enough equipment which was previously too fragile to use for long.$(br)With your full armada of nearly-indestructible items now, though? No problem."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/inexorable.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/inexorable.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You have come a long way and nothing could stop you. Except for the few times in Ocean Temples with mining fatigue, slowness, mining underwater, in the air and other adverse conditions...$(br2)$(italic)Hm, written out like this, that was a bit more than expected$()."
+      "text": "You have come a long way and nothing can stop you. Except for the few times in Ocean Temples with mining fatigue, slowness, mining underwater, in the air and other adverse conditions...$(br2)$(italic)Hm, written out like this, that was a bit more than expected$()."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/razing.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/razing.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Even with a list of enchantments that you can barely read anymore due to its length, there are still few blocks that escape your gaze of superiority.$(br2)$(item)Obsidian$(), you are getting cancelled today."
+      "text": "Even with a list of enchantments that you can barely read anymore due to its length, there are still a few blocks that escape your gaze of superiority.$(br2)$(item)Obsidian$(), you are getting cancelled today."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/resonance.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/resonance.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "There have always been blocks that you were very interested in, but you could never carve them out of the ground carefully enough to retrieve them flawlessly. You noticed, however, that these blocks vibrate in a similar way to the gems you've been so concerned with lately.$(br)If you hit the right frequency, you finally can hold some of those blocks in your hands."
+      "text": "There have always been blocks that you were very interested in, but you could never carve them out of the ground carefully enough to retrieve them flawlessly. You noticed, however, that these blocks vibrate in a similar way to the gems you've been so concerned with lately.$(br)If you hit the right frequency, you can finally hold some of those blocks in your hands."
     },
     {
       "type": "patchouli:spotlight",
@@ -39,13 +39,13 @@
       "type": "patchouli:spotlight",
       "title": "Colored Leaves",
       "item": "spectrum:orange_leaves",
-      "text": "Colored Leaves get stimulated in a way to release a lot more $(item)saplings$().$(br2)Applied to a hoe his will finally be your key to get $(l:general/colored_trees)Colored Saplings$() renewably."
+      "text": "Colored Leaves get stimulated in a way to release a lot more $(item)saplings$().$(br2)Applied to a hoe this will finally be your key to get $(l:general/colored_trees)Colored Saplings$() renewably."
     },
     {
       "type": "patchouli:spotlight",
       "title": "Harvesting Spawners",
       "item": "minecraft:spawner",
-      "text": "In the depths, you have come across cages that seem to spit out an endless number of enemies. What madman put them there, what purpose they serve, and whether it was worth it is a mystery to you. But you can certainly find some use for them. Their creator hopefully won't miss you packing a few."
+      "text": "In the depths, you have come across cages that seem to spit out an endless number of enemies. What madman put them there, what purpose they serve, and whether it was worth it is a mystery to you. But you can certainly find some use for them. Their creator hopefully won't miss you taking a few."
     },
     {
       "type": "patchouli:spotlight",
@@ -60,11 +60,8 @@
     {
       "type": "spectrum:collection",
       "title": "Brushable Blocks",
-      "items": [
-        "minecraft:suspicious_sand",
-        "minecraft:suspicious_gravel"
-      ],
-      "text": "Sculk Shriekers retain their ability to summon the Warden."
+      "items": ["minecraft:suspicious_sand", "minecraft:suspicious_gravel"],
+      "text": "Brushable blocks retain their loot and can be brushed later."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/sniper.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/sniper.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Compared to the $(item)Bow$(), the $(item)Crossbow$() maintains a rather inconspicuous existence.$(br2)With the Sniping Enchantment however, it turns the crossbow into a deadly ranged weapon."
+      "text": "Compared to the $(item)Bow$(), the $(item)Crossbow$() maintains a rather inconspicuous existence.$(br2)With the Sniping Enchantment however, the crossbow becomes a deadly ranged weapon."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/steadfast.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/steadfast.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Knowing you, you create the perfect tool for yourself, only to have it fall into lava in a moment of derangement. And then there is the dimension of the Endermen, which dramatically punishes every mistake.$(br2)This new enchantment will protect your favorite tools in case of such an emergency (and be it throwing it against a cactus)."
+      "text": "Knowing you, you will create the perfect tool for yourself, only to have it fall into lava in a moment of derangement. And then there is the dimension of the Endermen, which dramatically punishes every mistake.$(br2)This new enchantment will protect your favorite tools in case of such an emergency (including throwing it against a cactus)."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/treasure_hunter.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/enchanting/treasure_hunter.json
@@ -13,7 +13,7 @@
       "type": "patchouli:spotlight",
       "title": "Getting Mob Heads",
       "item": "spectrum:cow_head",
-      "text": "But then there were the Creepers! Struck by lightning, they explode so hefty that they blow their opponent's heads right off their necks (worst case: yours).$(br)To replicate this, you thought out this new enchantment using $(l:resources/storm_stones)Storm Stones$(/l).$(br)And so Treasure Hunter was born, allowing you to collect $(l:creating_life/mob_heads)all kinds of Mob Heads$(/l)."
+      "text": "But then there were the Creepers! Struck by lightning, they explode so forcefully that they blow their opponent's heads right off their necks (worst case: yours).$(br)To replicate this, you thought out this new enchantment using $(l:resources/storm_stones)Storm Stones$(/l).$(br)And so Treasure Hunter was born, allowing you to collect $(l:creating_life/mob_heads)all kinds of Mob Heads$(/l)."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/ashen_circlet.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/ashen_circlet.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "The $(l:resources/stratine)Stratine Gem$() you set into this circlet, itself a creation of the Nether, can absorb high temperatures with ease.$(br)It even protects you from the blazing heat of Lava - if only for a short time.$(br)Pair it with $(thing)Fire Resistance$(), you're able to swim in Lava almost as if it were Water."
+      "text": "The $(l:resources/stratine)Stratine Gem$() you set into this circlet, itself a creation of the Nether, can absorb high temperatures with ease.$(br)It even protects you from the blazing heat of Lava - if only for a short time.$(br)When paired with $(thing)Fire Resistance$(), you're able to swim in Lava almost as if it were Water."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/azure_dike_equipment.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/azure_dike_equipment.json
@@ -11,12 +11,12 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "The results of combining $(l:resources/azurite)Azurite$(/l) and the protective properties of $(l:general/pigment#blue)Blue Pigment$(/l) really sparked your interest. The material seemed to surround itself with a transparent aura which took some effort to penetrate when you reached for the lump.$(br2)$(italic)This is going to be interesting..."
+      "text": "The results of combining $(l:resources/azurite)Azurite$(/l) with the protective properties of $(l:general/pigment#blue)Blue Pigment$(/l) really sparked your interest. The material seemed to surround itself with a transparent aura which took some effort to penetrate when you reached for the lump.$(br2)$(italic)This is going to be interesting..."
     },
     {
       "type": "patchouli:text",
       "title": "Azure Dike",
-      "text": "A magical aura surrounding your body, shielding you from incoming damage.$(br)Slowly, but steadily recharges up to a specific amount.$(br2)Each piece of Azure Dike Equipment increases the maximum amount of protection."
+      "text": "A magical aura surrounding your body, shielding you from incoming damage.$(br)Slowly but steadily recharges up to a specific amount.$(br2)Each piece of Azure Dike Equipment increases the maximum amount of protection."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",
@@ -37,7 +37,7 @@
       "title": "Shieldgrasp Amulet",
       "advancement": "spectrum:unlocks/trinkets/shieldgrasp_amulet",
       "recipe": "spectrum:fusion_shrine/trinkets/shieldgrasp_amulet",
-      "text": "Infuse it with $(l:magic/ink)Blue Ink$(/l) in a $(l:magic/color_picker)Color Picker$() to increase the amount of $(c_blue)Azure Dike$() provided.$(br)Cheap at first, the required energy to infuse more power into this amulet increases exponentially."
+      "text": "Infuse it with $(l:magic/ink)Blue Ink$(/l) in a $(l:magic/color_picker)Color Picker$() to increase the amount of $(c_blue)Azure Dike$() provided.$(br)Cheap at first, but the required energy to infuse more power into this amulet increases exponentially."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/circlet_of_arrogance.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/circlet_of_arrogance.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "That's it: Ascension - the ultimate buff - in wearable form.$(br)If your mere existence wouldn't be in danger everytime you get hit too hard - a very expensive price to pay - you would not hesitate for a second putting it on.$(br)Should you really...?$(br2)Of course."
+      "text": "That's it: Ascension - the ultimate buff - in wearable form.$(br)If your mere existence wasn't in danger every time you get hit too hard - a very expensive price to pay - you would not hesitate for a second to put it on.$(br)Should you really...?$(br2)Of course."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/cotton_cloud_boots.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/cotton_cloud_boots.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "To be able to fly like the birds has always been the dream of many people, including you.$(br2)Now you got those boots. The freedom is almost overwhelming. You didn't get it quite right without a catch, but what can you do."
+      "text": "To be able to fly like the birds has always been the dream of many people, including you.$(br2)Now you have these boots. The freedom is almost overwhelming. You didn't get it quite right without a catch, but what can you do."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/dreamflayer.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/dreamflayer.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "A truly exceptional weapon, it embodies the definition of \"offense is a good defense.\"$(br)It is the nature of the Dreamflayer to balance forces:$(br)The more armored your opponent is compared to you, the more damage it will do."
+      "text": "A truly exceptional weapon, it embodies the definition of \"offense is the best defense.\"$(br)It is the nature of the Dreamflayer to balance forces:$(br)The more armored your opponent is compared to you, the more damage it will do."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/glass_arrows.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/glass_arrows.json
@@ -26,7 +26,7 @@
     {
       "type": "spectrum:pedestal_crafting",
       "recipe": "spectrum:pedestal/tier1/arrows/amethyst_glass_arrow",
-      "text": "Also freezes the target, slowing them down. Also deals freezing damage over time."
+      "text": "Also freezes the target, slowing them down and dealing freezing damage over time."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/glass_crest_tools.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/glass_crest_tools.json
@@ -28,7 +28,7 @@
       "title": "Ultra Greatsword",
       "advancement": "spectrum:unlocks/malachite/glass_crest_ultra_greatsword",
       "recipe": "spectrum:fusion_shrine/malachite/glass_crest_ultra_greatsword",
-      "text": "Deals a chunk of it's damage via $(thing)Magic$() - piercing armor. $(k:use) to charge a $(thing)ground slam$(), knocking back everything around you. This ability scales with $(thing)Sweeping$())."
+      "text": "Deals a chunk of its damage via $(thing)Magic$(), which pierces armor. $(k:use) to charge a $(thing)ground slam$(), knocking back everything around you. This ability scales with $(thing)Sweeping$())."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/jeopardant.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/jeopardant.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Adrenaline does not have to be the only thing racing through your veins in state of emergency.$(br2)With every heart lost, the $(l:resources/stratine)Stratine Gem$() in this ring shines brighter and brighter, pulsating in the same rhythm as your racing heart - granting you an exponential damage boost."
+      "text": "Adrenaline does not have to be the only thing racing through your veins in a state of emergency.$(br2)With every heart lost, the $(l:resources/stratine)Stratine Gem$() in this ring shines brighter and brighter, pulsating in the same rhythm as your racing heart - granting you an exponential damage boost."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/lagoon_rod.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/lagoon_rod.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "On quiet days on your patio you could observe that the $(l:resources/mermaids_brush)Mermaid's Gems$() you found that marine life seems oddly attracted to them. Along with the fact that they naturally float on water, you decided to use one as a bobber.$(br2)Lo and behold, not only does it increase your success, but also have quite a few other interesting side effects..."
+      "text": "On quiet days on your patio you could observe that marine life seems oddly attracted to the $(l:resources/mermaids_brush)Mermaid's Gems$() you found. Since they naturally float on water, you decided to use one as a bobber.$(br2)Lo and behold, not only does it increase your success, but also has quite a few other interesting side effects..."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/malachite_tools.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/malachite_tools.json
@@ -33,7 +33,7 @@
       "title": "Bident",
       "anchor": "bident",
       "recipe": "spectrum:fusion_shrine/malachite/malachite_bident",
-      "text": "A true powerhouse when dealing with aquatic creatures.$(br2)$(italic)It may have only two prongs compared to a $(item)Trident$()$(italic), but those are twice as pointy!"
+      "text": "A true powerhouse when dealing with aquatic creatures.$(br2)$(italic)It may have only two prongs compared to a $(item)Trident$()$(italic), but they are twice as pointy!"
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/molten_rod.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/molten_rod.json
@@ -9,13 +9,13 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Orange, representing warmth, can be used to do the most interesting things.$(br2)Unlike a normal $(item)Fishing Rod$(), this one a lot more sturdy and is able to fish where a common rod fails.$(br)You wonder what you can bring to the surface?"
+      "text": "Orange, representing warmth, can be used to do the most interesting things.$(br2)Unlike a normal $(item)Fishing Rod$(), this one is a lot more sturdy and is able to fish where a common rod fails.$(br)You wonder what you can bring to the surface?"
     },
     {
       "type": "spectrum:pedestal_crafting",
       "title": "Pedestal Recipe",
       "recipe": "spectrum:pedestal/tier1/tools/molten_rod",
-      "text": "$(italic)Caution, hot!$()$(br)Its flaming fishing hook can not only burn your fingers..."
+      "text": "$(italic)Caution, hot!$()$(br)Its flaming fishing hook can burn more than just your fingers..."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/radiance_pin.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/radiance_pin.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You didn't randomly choose the name of the Radiance Pin to resemble the $(l:magical_items/radiance_staff)Radiance Staff$(/l).$(br)If you are in a dark area, the pin automatically creates an invisible light on you. Unlike the lights of the $(l:magical_items/radiance_staff)Radiance Staff$(/l), however, they slowly become fainter and fainter until they eventually dissipate completely."
+      "text": "You didn't name the Radiance so similar to the $(l:magical_items/radiance_staff)Radiance Staff$(/l) on accident.$(br)If you are in a dark area, the pin automatically creates an invisible light on you. Unlike the lights of the $(l:magical_items/radiance_staff)Radiance Staff$(/l), however, they slowly become fainter and fainter until they eventually dissipate completely."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/ring_of_pursuit.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/equipment/ring_of_pursuit.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Mining is your game. It's almost a miracle that you're only now coming around to the idea of upgrading not only your tools, but your mining proficiency in general. This ring will grow with your abilities."
+      "text": "Mining is your game. It's almost a miracle that you're only now coming up with the idea of upgrading not only your tools, but your mining proficiency in general. This ring will grow with your abilities."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/intro.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/intro.json
@@ -7,15 +7,13 @@
     {
       "type": "patchouli:image",
       "title": "Welcome to Spectrum!",
-      "images": [
-        "spectrum:textures/gui/guidebook/spectrum.png"
-      ],
+      "images": ["spectrum:textures/gui/guidebook/spectrum.png"],
       "border": true,
       "text": "Spectrum is a progression- and exploration-driven magic mod where you combine colors."
     },
     {
       "type": "patchouli:text",
-      "text": "Its color mixing of the subtractive color system (CMYK). Subtractive color mixing may be familiar to you from painting with watercolors or printing.$(br2)Spectrum's main colors are represented by gemstones, found in geodes scattered around the world, with the vanilla Amethyst representing the Magenta part of the spectrum."
+      "text": "It's color mixing of the subtractive color system (CMYK). Subtractive color mixing may be familiar to you from painting with watercolors or printing.$(br2)Spectrum's main colors are represented by gemstones, found in geodes scattered around the world, with the vanilla Amethyst representing the Magenta part of the spectrum."
     },
     {
       "type": "patchouli:text",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/midnight_aberration.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/midnight_aberration.json
@@ -11,13 +11,13 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Your latest findings of your $(l:creating_life/failing)last experiment$() make you strive for more and more: to squeeze every last ounce of energy out of your Gemstones.$(br2)$(l:creating_life/failing#neolith)Neolith$() is the key! With such strength and power, it will combine the powers of all the gemstones into one. This relic will be the capstone to your creation, alone for you and ONLY for you, master of Pigment!"
+      "text": "The findings from your $(l:creating_life/failing)last experiment$() make you strive for more and more: to squeeze every last ounce of energy out of your Gemstones.$(br2)$(l:creating_life/failing#neolith)Neolith$() is the key! With such strength and power, it will combine the powers of all the gemstones into one. This relic will be the capstone to your creation, alone for you and ONLY for you, master of Pigment!"
     },
     {
       "type": "spectrum:fusion_shrine_crafting",
       "title": "Fusion Recipe",
       "recipe": "spectrum:fusion_shrine/midnight_aberration",
-      "text": "The fusion of these magical energies will try your Shrine like nothing before - with a display to match. Best to make sure your shrine and the blocks around it are fortified.$(br)Requires daytime and a clear sky."
+      "text": "The fusion of these magical energies will try your Shrine like nothing before - with a display to match. Who knows what might manifest? Best to make sure your shrine and the blocks around it are fortified and isolated.$(br)Requires daytime and a clear sky."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/mysterious_locket.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/mysterious_locket.json
@@ -13,7 +13,7 @@
       "type": "patchouli:spotlight",
       "title": "A Mysterious Locket",
       "item": "spectrum:mysterious_locket",
-      "text": "This small locket is tight shut. It features an odd ornament which resembles a notch, softly glowing a pale white color, a shimmer reminiscent of the moon.$(br)There seems to be something inside. It also has an engraving on its back, but if it even resembles a language it's none you have ever seem.$(br)Who left it behind?"
+      "text": "This small locket is shut tight. It features an odd ornament which resembles a notch, softly glowing a pale white color, a shimmer reminiscent of the moon.$(br)There seems to be something inside. It also has an engraving on its back, but if it even resembles a language it's none you have ever seem.$(br)Who left it behind?"
     },
     {
       "type": "spectrum:fusion_shrine_crafting",
@@ -26,14 +26,12 @@
       "type": "patchouli:text",
       "title": "The Locket's Contents",
       "advancement": "spectrum:endgame/open_mysterious_compass",
-      "text": "The locket contained a small crystal, bearing a dimmer, yet much warmer glow than it's lock.$(br)While $(l:dimension/getting_deeper_down)below the Bedrock(/l), it softly vibrates as you turn."
+      "text": "The locket contained a small crystal, bearing a dimmer, yet much warmer glow than its lock.$(br)While $(l:dimension/getting_deeper_down)below the Bedrock(/l), it softly vibrates as you turn."
     },
     {
       "type": "patchouli:image",
       "advancement": "spectrum:__todo",
-      "images": [
-        "spectrum:textures/gui/guidebook/locket.png"
-      ],
+      "images": ["spectrum:textures/gui/guidebook/locket.png"],
       "border": true,
       "text": "There also was a small note inside... who could it have belonged to?"
     },

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/paintbrush.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/paintbrush.json
@@ -23,7 +23,7 @@
       "type": "patchouli:text",
       "title": "Block Coloring",
       "advancement": "spectrum:collect_pigment",
-      "text": "What better use is there for $(l:general/pigment)Pigment$() than coloring with it?$(br)$(thing)Crouch while having your Paintbrush equipped to bring up the color selection menu$(). You just have to slightly touch the block you would like to color for the $(l:general/pigment)Pigment$() to flow into it and convert it into it's colored variant."
+      "text": "What better use is there for $(l:general/pigment)Pigment$() than coloring with it?$(br)$(thing)Crouch while having your Paintbrush equipped to bring up the color selection menu$(). You just have to slightly touch the block you would like to color for the $(l:general/pigment)Pigment$() to flow into it and convert it into its colored variant."
     },
     {
       "type": "patchouli:text",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pedestal.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pedestal.json
@@ -14,7 +14,7 @@
       "type": "patchouli:crafting",
       "title": "Pigment Pedestal",
       "recipe": "spectrum:crafting_table/pedestal_basic_amethyst",
-      "text": "The $(bold)Pigment Pedestal$() is the block where you craft most of the recipes for Spectrum.$(br2)To start crafting trigger it with a $(l:general/paintbrush)Paintbrush$() or supply a $(thing)redstone signal$().$(br)It requires air, or an inventory above it."
+      "text": "The $(bold)Pigment Pedestal$() is the block where you craft most of the recipes for Spectrum.$(br2)To start crafting trigger it with a $(l:general/paintbrush)Paintbrush$() or supply a $(thing)redstone signal$().$(br)It requires air or an inventory above it."
     },
     {
       "type": "patchouli:text",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pedestal_upgrade_moonstone_2.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pedestal_upgrade_moonstone_2.json
@@ -10,7 +10,7 @@
       "type": "patchouli:spotlight",
       "title": "Moonstone Pedestal",
       "item": "spectrum:moonstone_chiseled_basalt",
-      "text": "Your latest structure feels... somewhat lacking. And now you also know exactly what is missing: more $(c_white)Moonstone$() exactly. The tricky part: Creating the required $(item)Moonstone Chiseled Blocks$() would require you being able to use your $(item)Moonstone Pedestal$() to it's full capability already.$(br)$(italic)Could there be a way to get around that?"
+      "text": "Your latest structure feels... somewhat lacking. And now you also know exactly what is missing: more $(c_white)Moonstone$(). The tricky part: Creating the required $(item)Moonstone Chiseled Blocks$() would require you being able to use your $(item)Moonstone Pedestal$() to it's full capability already.$(br)$(italic)Could there be a way to get around that?"
     },
     {
       "type": "patchouli:multiblock",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pigment.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pigment.json
@@ -43,7 +43,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Finally! You were able to obtain absolutely pure color pigments from the leaves of $(l:general/colored_trees)Colored Trees$().$(br)And by using a hoe harvesting them is pretty fast, too.$(br)These pigments, composed of their fundamentals $(bold)$(c_magenta)TIME$(), $(bold)$(c_yellow)ENERGY$() and $(bold)$(c_cyan)MATTER$(), definitely feel magical.$(br2)Still not fully convinced all of these even exist. How many can you find?"
+      "text": "Finally! You were able to obtain absolutely pure color pigments from the leaves of $(l:general/colored_trees)Colored Trees$().$(br)And when using a hoe harvesting them is pretty fast, too.$(br)These pigments, composed of their fundamentals $(bold)$(c_magenta)TIME$(), $(bold)$(c_yellow)ENERGY$() and $(bold)$(c_cyan)MATTER$(), definitely feel magical.$(br2)Still not fully convinced all of these even exist. How many can you find?"
     },
     {
       "type": "spectrum:checklist",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/preservation_ruins.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/preservation_ruins.json
@@ -44,7 +44,7 @@
       "type": "patchouli:spotlight",
       "title": "Preservation Ruins",
       "item": "spectrum:preservation_controller",
-      "text": "Deep underground you found this outlandish structure, which seems to be built from immensely sturdy stone. Whoever constructed them seemed to have knowledge way beyond your understanding.$(br)There has to be a way to get in there! If not now, then later... better keep the location in mind."
+      "text": "Deep underground you found this outlandish structure, which seems to be built from immensely sturdy stone. Whoever constructed them seems to have knowledge way beyond your understanding.$(br)There has to be a way to get in there! If not now, then later... better keep the location in mind."
     },
     {
       "type": "patchouli:text",
@@ -81,7 +81,7 @@
         "spectrum:textures/gui/guidebook/preservation_ruin_color_mixing.png"
       ],
       "border": true,
-      "text": "It was all so clear, in the end! You had it $(l:general/color_mixing)laid all out already$(/l)."
+      "text": "It was all so clear, in the end! You had it $(l:general/color_mixing)all laid out already$(/l)."
     },
     {
       "type": "patchouli:image",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/shards.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/shards.json
@@ -55,7 +55,7 @@
       "advancement": "spectrum:lategame/collect_moonstone_shard",
       "title": "Moonstone Shards",
       "item": "spectrum:moonstone_shard",
-      "text": "It's bluish-white shimmer reminds you of the soothing light of the moon on a calm summer night. The tranquility it exudes leaves a calming, yet significant impression, like a sleeping cat - balm for the soul and yet a predator, always on guard.$(br2)The Moonstone embodies pure $(bold)$(c_white)MAGIC$()."
+      "text": "Its bluish-white shimmer reminds you of the soothing light of the moon on a calm summer night. The tranquility it exudes leaves a calming, yet significant impression, like a sleeping cat - balm for the soul and yet a predator, always on guard.$(br2)The Moonstone embodies pure $(bold)$(c_white)MAGIC$()."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/what_happened.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/what_happened.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "$(italic)On the trail of the history of the Deeper Down$().$(br2)There is no question that, despite the lack of light, there must once have lived a highly advanced civilisation down here. But all you found wer ruins.$(br)What happened? Surely you can find clues to their whereabouts. Demise? Legacy?"
+      "text": "$(italic)On the trail of the history of the Deeper Down$().$(br2)There is no question that, despite the lack of light, there must once have lived a highly advanced civilisation down here. But all you found were ruins.$(br)What happened? Surely you can find clues to their whereabouts. Demise? Legacy?"
     },
     {
       "type": "spectrum:checklist",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/downstone_fragments.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/downstone_fragments.json
@@ -17,7 +17,7 @@
       "type": "spectrum:hint",
       "title": "Concise Instructions",
       "cost": "spectrum:moonstone_shard#24",
-      "text": "Near the lowest layers of the Deeper Down, you will sometimes stumble about structures with which the former inhabitants that were intricate enough to carve this stone."
+      "text": "Near the lowest layers of the Deeper Down, you will sometimes stumble across structures with which the former inhabitants were able to carve this stone."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/dragonbone.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/dragonbone.json
@@ -17,7 +17,7 @@
       "type": "spectrum:hint",
       "title": "Concise Instructions",
       "cost": "spectrum:doombloom_seed#12",
-      "text": "Dragonbone Blocks can be damaged using powerful explosions. You will need something with quite a bit more explosion power than TNT, for example Incandescent Amalgam. Though you feel that strong magical explosions might have a similar effect breaching their protective aura."
+      "text": "Dragonbone Blocks can be damaged using powerful explosions. You will need something with quite a bit more explosion power than TNT, for example Incandescent Amalgam. Though you feel that strong magical explosions might have a similar effect, breaching their protective aura."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/failing.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/failing.json
@@ -11,7 +11,7 @@
       "title": "Small Clue",
       "completion_advancement": "spectrum:midgame/collect_neolith",
       "cost": "spectrum:stratine_fragments#8",
-      "text": "Just like Fading, they prefer a specific block placed next to them. This time a lot more strong, though. 'I hate mining this'-strong, to be precise."
+      "text": "Just like Fading, they prefer a specific block placed next to them. This time a lot stronger, though. 'I hate mining this'-strong, to be precise."
     },
     {
       "type": "spectrum:hint",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/mermaids_gems.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/mermaids_gems.json
@@ -17,7 +17,7 @@
       "type": "spectrum:hint",
       "title": "Concise Instructions",
       "cost": "spectrum:onyx_shard#12",
-      "text": "The source of these gems is a coral-looking plant that grows on the seabed in small groups, looking like sea grass. Wait next to it until it is fully grown, releases its precious treasure and then collect it. After you got one, you will be able to see the plant for what it is."
+      "text": "The source of these gems is a coral-looking plant that grows on the seabed in small groups, disguised as sea grass. Wait next to it until it is fully grown and releases its precious treasure, then collect it. After you collect one, you will be able to see the plant for what it is."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/midnight_chip.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/midnight_chip.json
@@ -18,7 +18,7 @@
       "title": "Concise Instructions",
       "completion_advancement": "spectrum:midgame/collect_midnight_chip",
       "cost": "spectrum:neolith#24",
-      "text": "Midnight Solution has various effects depending on what lands in it. Enchanted items lose their magical powers, some items change altogether and creatures killed by it drop a small mysterious fragment."
+      "text": "Midnight Solution has various effects depending on what lands in it. Enchanted items lose their magical powers, some items change altogether, and creatures killed by it drop a small mysterious fragment."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/preservation_ruins.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/preservation_ruins.json
@@ -35,7 +35,7 @@
       "advancement": "spectrum:find_preservation_ruins",
       "completion_advancement": "spectrum:enter_wireless_redstone_preservation_ruin",
       "cost": "spectrum:refined_azurite#12",
-      "text": "Is there a way to crack open the Bedrock? After you get in, best to take a look at the corresponding pages in your book of everything you find there. Always good to have some dyes with you."
+      "text": "Is there a way to crack open the Bedrock? After you get in, best to take a look at the corresponding pages in your book for everything you find there. Always good to have some dyes with you."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magic/color_picker.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magic/color_picker.json
@@ -6,7 +6,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Converts $(l:general/pigment)Pigment$(/l) into pure $(l:magic/ink)Ink$(), which you can supply to your magical items.$(br)Used to fill Ink Containers, like $(l:magic/ink_flask)Ink Flasks$().$(br)Unfortunately - $(l:magic/ink#transfer)you remember how Ink is transferred$() - there is always residue left behind. You can't use the full amount, though the transfer is quicker, the bigger the difference."
+      "text": "Converts $(l:general/pigment)Pigment$(/l) into pure $(l:magic/ink)Ink$(), which you can supply to your magical items.$(br)Used to fill Ink Containers, like $(l:magic/ink_flask)Ink Flasks$().$(br)Unfortunately - $(l:magic/ink#transfer)you remember how Ink is transferred$() - there is always residue left behind. You can't use the full amount, though the transfer is quicker the bigger the difference."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magic/crystal_apothecary.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magic/crystal_apothecary.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Placed in $(l:resources/geodes)Geodes$(/l), automatically harvests fully grown $(item)Gemstone Clusters$().$(br2)Normally all your other constructions and even crops do pretty much freeze in time when you are away, but this construct seems to continue working even then. Weird."
+      "text": "Placed in $(l:resources/geodes)Geodes$(/l), automatically harvests fully grown $(item)Gemstone Clusters$().$(br2)Normally all your other constructions and even crops pretty much freeze in time when you are away, but this construct seems to continue working even then. Weird."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magic/ink.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magic/ink.json
@@ -12,20 +12,18 @@
     {
       "type": "patchouli:text",
       "title": "Producing & Storing",
-      "text": "$(l:general/pigment)Pigment$() can be converted to Ink using the $(l:magic/color_picker)Color Picker$(/l) and then extracted into containers, like $(l:magic/ink_flask)Ink Flasks$(/l).$(br2)The only drawback: deprived of it's physical form, there is no way to transform Ink back into $(l:general/pigment)Pigment$()."
+      "text": "$(l:general/pigment)Pigment$() can be converted to Ink using the $(l:magic/color_picker)Color Picker$(/l) and then extracted into containers, like $(l:magic/ink_flask)Ink Flasks$(/l).$(br2)The only drawback: deprived of its physical form, there is no way to transform Ink back into $(l:general/pigment)Pigment$()."
     },
     {
       "type": "patchouli:image",
       "title": "Transfer",
       "anchor": "transfer",
-      "images": [
-        "spectrum:textures/gui/guidebook/ink_transfer.png"
-      ],
+      "images": ["spectrum:textures/gui/guidebook/ink_transfer.png"],
       "text": "Ink behaves very much like a liquid. It flows from where it is abundant to where is little."
     },
     {
       "type": "patchouli:text",
-      "text": "$(br)When two objects that store Ink are connected - such as a $(l:magic/color_picker)Color Picker$() and an $(l:magic/ink_flask)Ink Flask$() - the Ink between the two containers slowly evens out.$(br)The greater the difference, the faster the Flask is getting filled."
+      "text": "$(br)When two objects that store Ink are connected - such as a $(l:magic/color_picker)Color Picker$() and an $(l:magic/ink_flask)Ink Flask$() - the Ink between the two containers slowly evens out.$(br)The greater the difference, the faster the Flask is filled."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/bedrock_anvil.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/bedrock_anvil.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You've already used your anvil plenty (lots of anvils, to be precise). $(l:general/anvil_crushing)Item Crushing$(/l), repairing and enchanting  are burning a hole in your iron supply.$(br)To make the anvil last longer - or even make it indestructible - Bedrock seems like the perfect choice.$(br)Allows you to rename items for free and has no maximum repair limit."
+      "text": "You've already used your anvil plenty (lots of anvils, to be precise). $(l:general/anvil_crushing)Item Crushing$(/l), repairing and enchanting are burning a hole in your iron supply.$(br)To make the anvil last longer - or even make it indestructible - Bedrock seems like the perfect choice.$(br)Allows you to rename items for free and has no maximum repair limit."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/compacting_chest.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/compacting_chest.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "You are long tired of creating new storage space for all the coal, iron, copper and gold that are piling up in your storage room. Then, assembling this stuff to more compact clumps again and again is no fun, either.$(br2)So you thought up the Compacting Chest that takes this monotonous work off your hands."
+      "text": "You are long tired of creating new storage space for all the coal, iron, copper and gold that are piling up in your storage room. Assembling this stuff to more compact clumps again and again is no fun, either.$(br2)So, you thought up the Compacting Chest, which takes this monotonous work off your hands."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/crystallarieum.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/crystallarieum.json
@@ -65,7 +65,7 @@
     {
       "type": "patchouli:text",
       "title": "Catalysts",
-      "text": "The Crystallarieum also fits a stack of catalysts, speed up the process, or lower Ink consumption. While catalysts are mostly optional, some special materials may require them."
+      "text": "The Crystallarieum also fits a stack of catalysts, which can speed up the process or lower Ink consumption. While catalysts are mostly optional, some special materials may require them."
     },
     {
       "type": "spectrum:crystallarieum_growing",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/midnight_solution.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/midnight_solution.json
@@ -20,7 +20,7 @@
       "item": "spectrum:midnight_chip",
       "anchor": "midnight_chip",
       "advancement": "spectrum:midgame/collect_midnight_chip",
-      "text": "Creatures that died in that feisty liquid drop a small splinter that almost resembles a $(l:general/midnight_aberration)Midnight Aberration$(/l), just way, way smaller. Sharp-Edged and vicious.$(br)Creatures unalived by this cruel process also seem to $(thing)drop items as if they were killed by a player$()."
+      "text": "Creatures that die in that feisty liquid drop a small splinter that almost resembles a $(l:general/midnight_aberration)Midnight Aberration$(/l), just way, way smaller. Sharp-Edged and vicious.$(br)Creatures unalived by this cruel process also seem to $(thing)drop items as if they were killed by a player$()."
     },
     {
       "type": "spectrum:potion_workshop_crafting",
@@ -28,7 +28,7 @@
       "recipe": "spectrum:potion_workshop_crafting/midnight_solution_bucket",
       "advancement": "spectrum:unlocks/blocks/midnight_solution",
       "text": "Using the exact drop that you got by killing creatures with that fluid you can create even more of it. Quite morbid, if you think about it."
-    },	
+    },
     {
       "type": "patchouli:spotlight",
       "title": "Black Materia",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/mud.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/mud.json
@@ -11,7 +11,7 @@
       "type": "patchouli:spotlight",
       "title": "Liquid Mud",
       "item": "spectrum:mud_bucket",
-      "text": "Mud. It is wet mud. Not particularly interesting in itself. What is practical is the collision of the mud with other liquids, like $(item)Water$() or $(item)Lava$(). This creates $(item)Dirt$() or $(item)Coarse Dirt$(), respectively."
+      "text": "Mud. It is wet mud. Not particularly interesting in and of itself. What is practical is the collision of the mud with other liquids, like $(item)Water$() or $(item)Lava$(). This creates $(item)Dirt$() or $(item)Coarse Dirt$(), respectively."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/upgrades.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_blocks/upgrades.json
@@ -17,7 +17,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Pigment Pedestal and Fusion Shrine have already proven their worth. But there is still plenty of room for improvement. That's why you created these upgrades. Each one improves the properties of your structures in a different way, depending on what's most important to you personally.$(br)Additional ones of the same type have a decreased effect."
+      "text": "The Pigment Pedestal and Fusion Shrine have already proven their worth. But there is still plenty of room for improvement. That's why you created these upgrades. Each one improves the properties of your structures in a different way, depending on what's most important to you personally.$(br)Additional upgrades of the same type have a decreased effect."
     },
 
     {

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/crafting_tablet.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/crafting_tablet.json
@@ -11,7 +11,7 @@
       "type": "spectrum:pedestal_crafting",
       "title": "Crafting Tablet",
       "recipe": "spectrum:pedestal/tier1/crafting_tablet",
-      "text": "The Crafting Tablet is so much more than a portable Crafting Table. It saves a recipe you inserted and let's you craft it on demand."
+      "text": "The Crafting Tablet is so much more than a portable Crafting Table. It saves a recipe you inserted and lets you craft it on demand."
     },
     {
       "type": "patchouli:text",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/ender_splice.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/ender_splice.json
@@ -16,7 +16,7 @@
       "type": "spectrum:pedestal_crafting",
       "title": "Pedestal Recipe",
       "recipe": "spectrum:pedestal/tier3/ender_splice",
-      "text": "Use it to bind it to your current position.$(br)The second use will teleport you back. Can even be used on other players. Cannot teleport you across dimensions."
+      "text": "Use via $(k:use) to bind it to your current position.$(br)The second use will teleport you back. Can even be used on other players. Cannot teleport you across dimensions."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/ender_splice.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/ender_splice.json
@@ -16,7 +16,7 @@
       "type": "spectrum:pedestal_crafting",
       "title": "Pedestal Recipe",
       "recipe": "spectrum:pedestal/tier3/ender_splice",
-      "text": "Change it to bind it to your current position.$(br)The second use will teleport you back. Can even be used on other players. Cannot teleport you across dimensions."
+      "text": "Use it to bind it to your current position.$(br)The second use will teleport you back. Can even be used on other players. Cannot teleport you across dimensions."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/everpromise_ribbon.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/everpromise_ribbon.json
@@ -9,14 +9,14 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "A ribbon, gifted to pets as an everlasting promise to watch out and care for them.$(br)Name it, add Pigment to it in a Crafting Table and attach it on a creature."
+      "text": "A ribbon, gifted to pets as an everlasting promise to watch out and care for them.$(br)Name it and attach it on a creature. Should it ever die it will drop a $(item)Broken Promise$()."
     },
     {
       "type": "spectrum:pedestal_crafting",
       "title": "Pedestal Recipe",
       "advancement": "spectrum:unlocks/items/everpromise_ribbon_recipe",
       "recipe": "spectrum:pedestal/tier4/everpromise_ribbon",
-      "text": "Your pet receive its new, colored name, will immediately trust you if it does not already and - should it ever die - drop a $(item)Broken Promise$()."
+      "text": "Your pet will immediately trust you if it does not already. Use a $(item)Crafting Table$() to add $(l:general/pigment)Pigment$() to the $(item)Ribbon$() to give your pet a colored name."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/everpromise_ribbon.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/everpromise_ribbon.json
@@ -16,7 +16,7 @@
       "title": "Pedestal Recipe",
       "advancement": "spectrum:unlocks/items/everpromise_ribbon_recipe",
       "recipe": "spectrum:pedestal/tier4/everpromise_ribbon",
-      "text": "Your pet receive it's new, colored name, will immediately trust you if it does not already and - should it ever die - drop a $(item)Broken Promise$()."
+      "text": "Your pet receive its new, colored name, will immediately trust you if it does not already and - should it ever die - drop a $(item)Broken Promise$()."
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/exchanging_staff.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/exchanging_staff.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "For all those who don't live in a simple $(item)Cobblestone$() house, or don't have walls at all - of course you don't feel addressed - you have thought up the Exchanging Staff."
+      "text": "For all those who don't either live in a simple $(item)Cobblestone$() house, or have no walls at all - of course you don't feel addressed - you have thought up the Exchanging Staff."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/exchanging_staff.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/exchanging_staff.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "For all those who don't either live in a simple $(item)Cobblestone$() house, or have no walls at all - of course you don't feel addressed - you have thought up the Exchanging Staff."
+      "text": "For all those who don't either live in a simple $(item)Cobblestone$() house or live without walls entirely - of course you don't feel addressed - you have thought up the Exchanging Staff."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/incandescent_amalgam.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/incandescent_amalgam.json
@@ -13,7 +13,7 @@
     },
     {
       "type": "patchouli:text",
-      "text": "A single wrong move could easily cause it to detonate, taking everything nearby with it including yourself. And yet, for all those reasons and yet more, the soft, warm glow of the gel elicits endless curiosity, all things are drawn to the flame. There is no question that what is effectively a high yield magical explosive bears endless potential. All you need is a little care, a small mountain of it, and a hint of reckless abandon."
+      "text": "A single wrong move could easily cause it to detonate, taking everything nearby with it including yourself. And yet, for all those reasons and more, the soft, warm glow of the gel elicits endless curiosity. All things are drawn to the flame. There is no question that what is effectively a high yield magical explosive bears endless potential. All you need is a little care, a small mountain of it, and a hint of reckless abandon."
     },
     {
       "type": "spectrum:titration_barrel_fermenting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/radiance_staff.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/magical_items/radiance_staff.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Torches have one crucial weakness: you can only place them when you're already standing in the dark. In contrast the Radiance Staff can place lights far away and in the air, illuminating large caverns at a distance.$(br)As a final goodie, these lights are invisible, making them great for illuminating your structures atmospherically."
+      "text": "Torches have one crucial weakness: you can only place them when you're already standing in the dark. In contrast, the Radiance Staff can place lights far away and in the air, illuminating large caverns at a distance.$(br)As a final goodie, these lights are invisible, making them great for illuminating your structures atmospherically."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/mod_integration/chalk.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/mod_integration/chalk.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Getting lost in the belows time and time again made you carry a bit of $(item)Chalk$() with you, allowing you to mark your way back out. Sadly these little pieces of Calcite never last long before breaking."
+      "text": "Getting lost deep below time and time again made you carry a bit of $(item)Chalk$() with you, allowing you to mark your way back out. Sadly these little pieces of Calcite never last long before breaking."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/mod_integration/tech_reborn.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/mod_integration/tech_reborn.json
@@ -13,7 +13,7 @@
       "type": "patchouli:spotlight",
       "item": "spectrum:amethyst_ore",
       "advancement": "spectrum:break_gemstone_ore",
-      "text": "Most of Spectrums Ores can be processed in the Grinder / Industrial Grinder to extract resources."
+      "text": "Most of Spectrum's Ores can be processed in the Grinder / Industrial Grinder to extract resources."
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/azurite.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/azurite.json
@@ -22,14 +22,14 @@
       "type": "patchouli:spotlight",
       "title": "Azurite",
       "item": "spectrum:raw_azurite",
-      "text": "A rich blue ore, which, at a distance, can almost be mistaken for $(item)Lapis$(). In its natural form it contains many impurities which must first be removed, before it can be used.$(br2)It is found deep underground and seems to be able to intensify any Pigment's energy."
+      "text": "A rich blue ore which, at a distance, can almost be mistaken for $(item)Lapis$(). In its natural form it contains many impurities which must first be removed before it can be used.$(br2)It is found deep underground and seems to be able to intensify any Pigment's energy."
     },
     {
       "type": "spectrum:fusion_shrine_crafting",
       "advancement": "spectrum:unlocks/resources/refined_azurite",
       "title": "Refining Azurite",
       "recipe": "spectrum:fusion_shrine/refined_azurite",
-      "text": "Refining Azurite is not a cheap task.$(br)In this refined ingot form Azurite can be used for a lot more recipes."
+      "text": "Refining Azurite is not a cheap task.$(br)In this refined ingot form Azurite can be used for many more recipes."
     },
     {
       "type": "spectrum:crystallarieum_growing",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/malachite.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/malachite.json
@@ -21,7 +21,7 @@
     {
       "type": "patchouli:text",
       "title": "Malachite",
-      "text": "A pristine material, that sparkles in a deep green hue. It seems to have strong magical properties, almost like a Deeper Down analog of $(l:resources/azurite)Azurite$(). In another similarity to $(l:resources/azurite)Azurite$(), Malachite also needs to be refined. The small fragments you obtain must first grow into full, usable crystals - though you're not sure you'll see them finished in your lifetime."
+      "text": "A pristine material that sparkles in a deep green hue. It seems to have strong magical properties, almost like a Deeper Down analog of $(l:resources/azurite)Azurite$(). In another similarity to $(l:resources/azurite)Azurite$(), Malachite also needs to be refined. The small fragments you obtain must first grow into full, usable crystals - though you're not sure you'll see them finished in your lifetime."
     },
     {
       "type": "spectrum:crystallarieum_growing",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/pure_resources.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/pure_resources.json
@@ -47,7 +47,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Growing materials in the $(l:magical_blocks/crystallarieum)Crystallarieum$(/l) yields this much more pure, crystalline variant compared to plain $(item)Raw Ore$().$(br2)On closer inspection they almost appear surrounded by an invisible sheen, gently protecting them from outside forces. This shroud also seems to be what protects $(item)Pure Copper$() from oxidization."
+      "text": "Growing materials in the $(l:magical_blocks/crystallarieum)Crystallarieum$(/l) yields this: a much more pure, crystalline variant compared to plain $(item)Raw Ore$().$(br2)On closer inspection they almost appear surrounded by an invisible sheen, gently protecting them from outside forces. This shroud also seems to be what protects $(item)Pure Copper$() from oxidization."
     },
     {
       "type": "patchouli:blasting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/quitoxic_reeds.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/quitoxic_reeds.json
@@ -11,9 +11,7 @@
     {
       "type": "patchouli:image",
       "title": "Quitoxic Reeds",
-      "images": [
-        "spectrum:textures/gui/guidebook/quitoxic_reed.png"
-      ],
+      "images": ["spectrum:textures/gui/guidebook/quitoxic_reed.png"],
       "border": true,
       "text": "Grows exclusively in Swamps and seems to devour Clay as a form of nutrient."
     },
@@ -22,7 +20,7 @@
       "title": "Quitoxic Powder",
       "anchor": "quitoxic_powder",
       "item": "spectrum:quitoxic_powder",
-      "text": "A purple glittering powder can be extracted from the stems of the alien-looking plant by crushing it with an anvil.$(br)Smell and consistency are very unusual when rubbed between your fingers.$(br2)$(italic)...wait a moment, what are fingers?"
+      "text": "A purple glittering powder can be extracted from the stems of the alien-looking plant by crushing it with an anvil.$(br)The smell and consistency are very unusual when rubbed between your fingers.$(br2)$(italic)...wait a moment, what are fingers?"
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/resonating_ender.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/resonating_ender.json
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Those pesky Endermen!$(br2)They always show up at night and steal blocks off the ground right from your nose. You have the feeling that the whole area here will be nothing but a single crater landscape in a month.$()"
+      "text": "Those pesky Endermen!$(br2)They always show up at night and steal blocks off the ground right from your nose. You have a feeling this whole area will be nothing but a crater in a month.$()"
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/shimmerstone.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/resources/shimmerstone.json
@@ -15,7 +15,7 @@
       "type": "patchouli:spotlight",
       "title": "Shimmerstone",
       "item": "spectrum:shimmerstone_gem",
-      "text": "A yellow ore that does not only emit energy in the form of light, but is able to manipulate it, too.$(br2)Shimmerstone is found close to sea level altitudes."
+      "text": "A yellow ore that not only emits energy in the form of light, but is able to manipulate it, too.$(br2)Shimmerstone is found close to sea level altitudes."
     },
     {
       "type": "spectrum:pedestal_crafting",


### PR DESCRIPTION
I noticed many small issues with the guidebook while playing, and this fixes most of them. Note that I attempted to keep the original "style" of the guidebook by preserving as much of the original wording as possible, which means I was not always able to fix the issues entirely. It's a necessary compromise since I wanted to avoid fully rewriting parts of the guidebook, since some of the original intent may be lost if I do.

Most of the changes are grammatical in nature or fix typos; the only 'content change' I made was rewording the Perfect Compound hint text to better warn players to isolate their fusion shrines.

If a more comprehensive rewrite is desired, let me know- the goal of this was to make as few changes as possible while still fixing most of the issues, but I could make the text much clearer (and improve the readability and flow) with a broader scope.