### PR TITLE
Add REI transfer handlers for Spectrum recipes

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/compat/REI/REIClientIntegration.java
+++ b/src/main/java/de/dafuqs/spectrum/compat/REI/REIClientIntegration.java
@@ -25,11 +25,17 @@ import me.shedaniel.rei.api.client.plugins.*;
 import me.shedaniel.rei.api.client.registry.category.*;
 import me.shedaniel.rei.api.client.registry.display.*;
 import me.shedaniel.rei.api.client.registry.screen.*;
+import me.shedaniel.rei.api.client.registry.transfer.TransferHandlerRegistry;
+import me.shedaniel.rei.api.client.registry.transfer.simple.SimpleTransferHandler;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.*;
+import me.shedaniel.rei.api.common.transfer.info.stack.SlotAccessor;
 import me.shedaniel.rei.api.common.util.*;
 import me.shedaniel.rei.plugin.common.*;
 import net.fabricmc.api.*;
 import net.minecraft.block.*;
+import net.minecraft.screen.ScreenHandler;
 
 @Environment(EnvType.CLIENT)
 public class REIClientIntegration implements REIClientPlugin {
@@ -157,5 +163,60 @@ public class REIClientIntegration implements REIClientPlugin {
 		
 		registry.registerDecider(REIOverlayDecider.INSTANCE);
 	}
-	
+
+	@SuppressWarnings("UnstableApiUsage")
+	@Override
+	public void registerTransferHandlers(TransferHandlerRegistry registry) {
+		registry.register(SimpleTransferHandlerExtension.create(PedestalScreenHandler.class, SpectrumPlugins.PEDESTAL_CRAFTING,
+				new SimpleTransferHandler.IntRange(0, 14), new SimpleTransferHandler.IntRange(16, 52)));
+		if (SpectrumCommon.CONFIG.canPedestalCraftVanillaRecipes()) {
+			registry.register(SimpleTransferHandlerExtension.create(PedestalScreenHandler.class, BuiltinPlugin.CRAFTING,
+					new SimpleTransferHandler.IntRange(0, 14), new SimpleTransferHandler.IntRange(16, 52)));
+		}
+		registry.register(SimpleTransferHandlerExtension.create(CinderhearthScreenHandler.class, SpectrumPlugins.CINDERHEARTH,
+				new SimpleTransferHandler.IntRange(2, 3), new SimpleTransferHandler.IntRange(11, 47)));
+		registry.register(SimpleTransferHandlerExtension.create(CinderhearthScreenHandler.class, BuiltinPlugin.BLASTING,
+				new SimpleTransferHandler.IntRange(2, 3), new SimpleTransferHandler.IntRange(11, 47)));
+		registry.register(SimpleTransferHandlerExtension.create(PotionWorkshopScreenHandler.class, SpectrumPlugins.POTION_WORKSHOP_BREWING,
+				new SimpleTransferHandler.IntRange(0, 9), new SimpleTransferHandler.IntRange(21, 57)));
+		registry.register(SimpleTransferHandlerExtension.create(PotionWorkshopScreenHandler.class, SpectrumPlugins.POTION_WORKSHOP_CRAFTING,
+				new SimpleTransferHandler.IntRange(0, 9), new SimpleTransferHandler.IntRange(21, 57)));
+	}
+
+	@SuppressWarnings("UnstableApiUsage")
+	interface SimpleTransferHandlerExtension extends SimpleTransferHandler {
+		// Because REI decided to give the create method with the inventory slots argument a different container class type.
+		// Pretty much identical to the original otherwise (except with slot handling changed to resemble the EMI counterpart)
+		static <C extends ScreenHandler, D extends Display> SimpleTransferHandler create(Class<? extends C> containerClass,
+																								 CategoryIdentifier<D> categoryIdentifier,
+																								 SimpleTransferHandler.IntRange inputSlots,
+																								 SimpleTransferHandler.IntRange inventorySlots) {
+			return new SimpleTransferHandler() {
+				@Override
+				public ApplicabilityResult checkApplicable(Context context) {
+					if (!containerClass.isInstance(context.getMenu())
+							|| !categoryIdentifier.equals(context.getDisplay().getCategoryIdentifier())
+							|| context.getContainerScreen() == null) {
+						return ApplicabilityResult.createNotApplicable();
+					} else {
+						return ApplicabilityResult.createApplicable();
+					}
+				}
+
+				@Override
+				public Iterable<SlotAccessor> getInputSlots(Context context) {
+					return context.getMenu()
+							.slots.subList(inputSlots.min(), inputSlots.maxExclusive())
+							.stream().map(SlotAccessor::fromSlot).toList();
+				}
+
+				@Override
+				public Iterable<SlotAccessor> getInventorySlots(Context context) {
+					return context.getMenu()
+							.slots.subList(inventorySlots.min(), inventorySlots.maxExclusive())
+							.stream().map(SlotAccessor::fromSlot).toList();
+				}
+			};
+		}
+	}
 }


### PR DESCRIPTION
Complementary to PR #330
Self explanatory, adds "Move Items" support for some Spectrum workstations on REI.
Matches functionality added by the EMI PR.
