### PR TITLE
Fix weird staff interaction

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/items/magic_items/NaturesStaffItem.java
+++ b/src/main/java/de/dafuqs/spectrum/items/magic_items/NaturesStaffItem.java
@@ -205,7 +205,9 @@ public class NaturesStaffItem extends Item implements ExtendedEnchantable, InkPo
 		}
 		
 		if (world.isClient) {
-			usageTickClient();
+			// Simple equality check to make sure this method doesn't execute on other clients.
+			// Always true if the current player is the one wielding the staff under normal circumstances.
+			if(MinecraftClient.getInstance().player == player) usageTickClient();
 		}
 	}
 	


### PR DESCRIPTION
The bug in question happens because `LivingEntity.usageTick` is executed on the server and ALL clients who have said entity loaded.
In order to fix this issue, a check must be implemented to ensure that the`clientUsageTick` method only executes on the player that is using the staff.
In my testing, a simple object identity check worked flawlessly for both the hosting player and a connected client instance.
