### PR TITLE
Remove jitpacked deps in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -67,11 +67,9 @@
     "minecraft": ">=1.20.1",
     "java": ">=17",
     "revelationary": "*",
-    "arrowhead": "*",
     "cloth-config": "*",
     "patchouli": "*",
-    "trinkets": "*",
-    "reverb": "*"
+    "trinkets": "*"
   },
   "suggests": {
     "chalk": "*",


### PR DESCRIPTION
Jitpacked deps are made within the mod itself, adding fabric.mod.json deps means that those are completely seperate mods/libraries to download on CF or modrinth.