### PR TITLE
Fix RU item.spectrum.pedestal.tooltip.all_basic

### DIFF
--- a/src/main/resources/assets/spectrum/lang/ru_ru.json
+++ b/src/main/resources/assets/spectrum/lang/ru_ru.json
@@ -1598,7 +1598,7 @@
   "item.spectrum.pedestal.tooltip.basic_topaz": "§bТопазовый§7",
   "item.spectrum.pedestal.tooltip.basic_amethyst": "§dАметистовый§7",
   "item.spectrum.pedestal.tooltip.basic_citrine": "§eЦитриновый§7",
-  "item.spectrum.pedestal.tooltip.all_basic": "Тройная игра цветов",
+  "item.spectrum.pedestal.tooltip.all_basic": "§bC§dM§eY§7",
   "item.spectrum.pedestal.tooltip.onyx": "§8Ониксовый§7",
   "item.spectrum.pedestal.tooltip.moonstone": "§fЛунокаменный§7",
   "block.spectrum.pastel_node": "Вайдовый Узел",


### PR DESCRIPTION
I used "Тройная игра цветов" as a substitute for the wordplay "CMY ON", but this phrase wouldn't work as a pedestal name tooltip. Let's just stick with colored "CMY" from English localization.