### PR TITLE
Clarify quitoxic reed biome

### DIFF
--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/quitoxic_reeds.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/hints/quitoxic_reeds.json
@@ -17,7 +17,7 @@
       "type": "spectrum:hint",
       "title": "Concise Instructions",
       "cost": "minecraft:clay_ball#48",
-      "text": "Strange looking plants have been seen in (Mangrove) Swamps, growing on patches of Clay or Mud. When growing, they will consume Clay/Mud in the process, turning it to Dirt."
+      "text": "Strange looking plants have been seen in Swamps and Mangrove Swamps, growing on patches of Clay or Mud. When growing, they will consume Clay/Mud in the process, turning it to Dirt."
     }
   ]
 }


### PR DESCRIPTION
Because some people don't read the page that says "visit a swamp or mangrove swamp" and then complain that the next page says "(mangrove) swamp" and therefore they thought swamps wouldn't work. Apparently.