### PR TITLE
Update 'a missing puzzle piece' reqs

### DIFF
--- a/src/main/resources/data/spectrum/advancements/lategame/build_complex_pedestal_structure_without_moonstone.json
+++ b/src/main/resources/data/spectrum/advancements/lategame/build_complex_pedestal_structure_without_moonstone.json
@@ -19,6 +19,10 @@
         "multiblock_identifier": "spectrum:pedestal_complex_structure_without_moonstone_check"
       }
     },
+    "built_complete_structure": {
+      "trigger": "spectrum:completed_multiblock",
+      "conditions": { "multiblock_identifier": "spectrum:pedestal_complex_structure_check" }
+    },
     "gotten_previous": {
       "trigger": "revelationary:advancement_gotten",
       "conditions": {
@@ -26,6 +30,15 @@
       }
     }
   },
+   "requirements":[
+    [
+      "built_structure",
+      "built_complete_structure"
+    ],
+    [
+      "gotten_previous"
+    ]
+  ]
   "rewards": {
     "experience": 500
   }

--- a/src/main/resources/data/spectrum/advancements/lategame/build_complex_pedestal_structure_without_moonstone.json
+++ b/src/main/resources/data/spectrum/advancements/lategame/build_complex_pedestal_structure_without_moonstone.json
@@ -38,7 +38,7 @@
     [
       "gotten_previous"
     ]
-  ]
+  ],
   "rewards": {
     "experience": 500
   }


### PR DESCRIPTION
Currently, it's possible to get the advancement for completing the moonstone-tier structure without getting the advancement for building the structure without moonstone chiseled blocks, which causes an incomplete guidebook category. First-time players won't know to add the moonstone chiseled blocks without the guidebook telling them, but repeat players may remember and then get confused by the incomplete category (which doesn't tell you what you're missing unless you know about the shift-click trick). This patch fixes that by allowing the advancement to trigger with both versions of the structure.