### PR TITLE
Make Dragonrot Orange Again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ dependencies {
 
 	// Mod Compat
 	modCompileOnly("maven.modrinth:colorful-hearts:${project.colorful_hearts_version}") { transitive = false }
+	modCompileOnly("maven.modrinth:sodium:${project.sodium_version}") { transitive = false }
 	modCompileOnly("com.unascribed:ears-api:${project.ears_version}")
 	// modCompileOnly("maven.modrinth:enchantment-descriptions:${project.enchantment_descriptions_version}")
 	modCompileOnly("maven.modrinth:travelersbackpack:${project.travelers_backpack_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,8 @@ arrowhead_version=797635e3c7
 mixin_extras_version=0.3.5
 # https://github.com/Terrails/colorful-hearts
 colorful_hearts_version=4.0.4
+# https://modrinth.com/mod/sodium
+sodium_version=dEpHs0Hg
 dimensional_reverb_version=26b0822932
 # https://github.com/Patbox/common-protection-api
 cpa_version=1.0.0

--- a/src/main/java/de/dafuqs/spectrum/mixin/compat/sodium/present/ColorProviderRegistryMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/compat/sodium/present/ColorProviderRegistryMixin.java
@@ -18,16 +18,24 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Arrays;
 
+// Since the color distortion bug isn't yet fixed,
+// nor is there an API for adding render overrides,
+// this mixin is needed.
 @Environment(EnvType.CLIENT)
 @Mixin(value = ColorProviderRegistry.class, remap = false)
 public abstract class ColorProviderRegistryMixin {
     @Shadow protected abstract void registerFluids(ColorProvider<FluidState> resolver, Fluid... fluids);
 
+
+    // see: https://github.com/CaffeineMC/sodium-fabric/blob/dev/src/main/java/net/caffeinemc/mods/sodium/client/model/color/ColorProviderRegistry.java#L35
     @Inject(method = "installOverrides", at = @At("RETURN"))
     private void spectrum$registerFluidColorProviders(CallbackInfo ci) {
         SpectrumFluids.HANDLER_MAP.forEach((handler, fluids) -> registerFluids(createProvider(handler), fluids));
     }
 
+
+    // A ColorProvider that properly swizzles the color value.
+    // The bugged Sodium one doesn't do this.
     @Unique
     private ColorProvider<FluidState> createProvider(FluidRenderHandler handler) {
         return (view, pos, state, quad, output) -> Arrays.fill(output, ColorARGB.toABGR(handler.getFluidColor(view, pos, state)));

--- a/src/main/java/de/dafuqs/spectrum/mixin/compat/sodium/present/ColorProviderRegistryMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/compat/sodium/present/ColorProviderRegistryMixin.java
@@ -1,0 +1,35 @@
+package de.dafuqs.spectrum.mixin.compat.sodium.present;
+
+import de.dafuqs.spectrum.registries.SpectrumFluids;
+import me.jellysquid.mods.sodium.client.model.color.ColorProvider;
+import me.jellysquid.mods.sodium.client.model.color.ColorProviderRegistry;
+import net.caffeinemc.mods.sodium.api.util.ColorARGB;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.FluidState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Arrays;
+
+@Environment(EnvType.CLIENT)
+@Mixin(value = ColorProviderRegistry.class, remap = false)
+public abstract class ColorProviderRegistryMixin {
+    @Shadow protected abstract void registerFluids(ColorProvider<FluidState> resolver, Fluid... fluids);
+
+    @Inject(method = "installOverrides", at = @At("RETURN"))
+    private void spectrum$registerFluidColorProviders(CallbackInfo ci) {
+        SpectrumFluids.HANDLER_MAP.forEach((handler, fluids) -> registerFluids(createProvider(handler), fluids));
+    }
+
+    @Unique
+    private ColorProvider<FluidState> createProvider(FluidRenderHandler handler) {
+        return (view, pos, state, quad, output) -> Arrays.fill(output, ColorARGB.toABGR(handler.getFluidColor(view, pos, state)));
+    }
+}

--- a/src/main/java/de/dafuqs/spectrum/registries/SpectrumFluids.java
+++ b/src/main/java/de/dafuqs/spectrum/registries/SpectrumFluids.java
@@ -4,6 +4,7 @@ import de.dafuqs.spectrum.*;
 import de.dafuqs.spectrum.api.color.*;
 import de.dafuqs.spectrum.blocks.fluid.*;
 import de.dafuqs.spectrum.helpers.*;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import net.fabricmc.api.*;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.*;
 import net.fabricmc.fabric.api.client.render.fluid.v1.*;
@@ -14,6 +15,9 @@ import net.minecraft.util.*;
 import org.joml.*;
 
 public class SpectrumFluids {
+
+	// RenderHandler storage for compatibility purposes
+	public static final Object2ObjectArrayMap<FluidRenderHandler, Fluid[]> HANDLER_MAP = new Object2ObjectArrayMap<>(4);
 	
 	// LIQUID CRYSTAL
 	public static final SpectrumFluid LIQUID_CRYSTAL = new LiquidCrystalFluid.Still();
@@ -71,11 +75,14 @@ public class SpectrumFluids {
 
 	@Environment(EnvType.CLIENT)
 	private static void setupFluidRendering(final Fluid stillFluid, final Fluid flowingFluid, final String name, int tint) {
-		FluidRenderHandlerRegistry.INSTANCE.register(stillFluid, flowingFluid, new SimpleFluidRenderHandler(
+		var handler = new SimpleFluidRenderHandler(
 				SpectrumCommon.locate("block/" + name + "_still"),
 				SpectrumCommon.locate("block/" + name + "_flow"),
 				tint
-		));
+		);
+
+		HANDLER_MAP.put(handler, new Fluid[]{stillFluid, flowingFluid});
+		FluidRenderHandlerRegistry.INSTANCE.register(stillFluid, flowingFluid, handler);
 
 		BlockRenderLayerMap.INSTANCE.putFluids(RenderLayer.getTranslucent(), stillFluid, flowingFluid);
 	}

--- a/src/main/resources/spectrum.mixins.json
+++ b/src/main/resources/spectrum.mixins.json
@@ -123,7 +123,8 @@
     "client.accessors.ParticleManagerAccessor",
     "client.accessors.RenderLayerAccessor",
     "compat.colorful_hearts.absent.InGameHudMixin",
-    "compat.colorful_hearts.present.HeartMixin"
+    "compat.colorful_hearts.present.HeartMixin",
+    "compat.sodium.present.ColorProviderRegistryMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fixes the stupid color format bug in Sodium for Spectrum fluids by adding color provider overrides with proper logic.