### PR TITLE
Update vein mining guidebook page requirements

### DIFF
--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/mod_integration/vein_mining.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/mod_integration/vein_mining.json
@@ -2,7 +2,7 @@
   "name": "Vein Mining",
   "icon": "spectrum:multitool",
   "flag": "mod:veinmining",
-  "advancement": "spectrum:lategame/collect_paltaeria",
+  "advancement": "spectrum:hidden/collect_stratine_gem",
   "category": "spectrum:mod_integration_category",
   "pages": [
     {


### PR DESCRIPTION
In 2aa886e6f1cfc7b92cef11c1f84d6828dc0f1e3a the Vein Mining enchanted book recipe was made cheaper and unlocks earlier, however the guidebook page still unlocks after collecting a paltaeria gem; this updates the unlock condition for the guidebook page to match the recipe unlock.