### PR TITLE
Fix Moonstone Pedestal Structure Name In Guidebook

### DIFF
--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pedestal_upgrade_moonstone.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pedestal_upgrade_moonstone.json
@@ -17,7 +17,7 @@
     },
     {
       "type": "patchouli:multiblock",
-      "name": "Spectrum Palace",
+      "name": "Spectrum Complex",
       "multiblock_id": "spectrum:pedestal_complex_structure_without_moonstone_check",
       "enable_visualize": true,
       "text": "Dimensions: 13x13x7 blocks"

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pedestal_upgrade_moonstone_2.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/general/pedestal_upgrade_moonstone_2.json
@@ -14,7 +14,7 @@
     },
     {
       "type": "patchouli:multiblock",
-      "name": "Spectrum Palace",
+      "name": "Spectrum Complex",
       "multiblock_id": "spectrum:pedestal_complex_structure_check",
       "enable_visualize": true,
       "text": "Dimensions: 13x13x7 blocks"


### PR DESCRIPTION
The advancement calls the moonstone-tier pedestal structure the "Spectrum Complex", while the guidebook pages reuse the Onyx-tier name ("Spectrum Palace"). This is almost certainly an oversight,