### PR TITLE
Minor fluid collision refactor

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/DragonrotFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/DragonrotFluidBlock.java
@@ -4,6 +4,7 @@ import de.dafuqs.spectrum.particle.*;
 import de.dafuqs.spectrum.registries.*;
 import net.minecraft.block.*;
 import net.minecraft.entity.ai.pathing.*;
+import net.minecraft.fluid.FluidState;
 import net.minecraft.particle.*;
 import net.minecraft.registry.tag.*;
 import net.minecraft.util.*;
@@ -39,43 +40,20 @@ public class DragonrotFluidBlock extends SpectrumFluidBlock {
 	public boolean canPathfindThrough(BlockState state, BlockView world, BlockPos pos, NavigationType type) {
 		return false;
 	}
-	
-	/**
-	 * @param world The world
-	 * @param pos   The position in the world
-	 * @param state BlockState of the mud. Included the height/fluid level
-	 * @return Dunno, actually. I just mod things.
-	 */
-	public boolean receiveNeighborFluids(World world, BlockPos pos, BlockState state) {
-		for (Direction direction : Direction.values()) {
-			BlockPos blockPos = pos.offset(direction);
-			if (world.getFluidState(blockPos).isIn(FluidTags.WATER)) {
-				world.setBlockState(pos, SpectrumBlocks.SLUSH.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			} else if (world.getFluidState(blockPos).isIn(FluidTags.LAVA)) {
-				world.setBlockState(pos, Blocks.BLACKSTONE.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			} else if (world.getFluidState(blockPos).isIn(SpectrumFluidTags.MUD)) {
-				world.setBlockState(pos, Blocks.MUD.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			} else if (world.getFluidState(blockPos).isIn(SpectrumFluidTags.LIQUID_CRYSTAL)) {
-				world.setBlockState(pos, SpectrumBlocks.ROTTEN_GROUND.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			} else if (world.getFluidState(blockPos).isIn(SpectrumFluidTags.MIDNIGHT_SOLUTION)) {
-				world.setBlockState(pos, SpectrumBlocks.BLACK_SLUDGE.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			}
+
+	public BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
+		if (otherState.isIn(FluidTags.WATER)) {
+			return SpectrumBlocks.SLUSH.getDefaultState();
+		} else if (otherState.isIn(FluidTags.LAVA)) {
+			return Blocks.BLACKSTONE.getDefaultState();
+		} else if (otherState.isIn(SpectrumFluidTags.MUD)) {
+			return Blocks.MUD.getDefaultState();
+		} else if (otherState.isIn(SpectrumFluidTags.LIQUID_CRYSTAL)) {
+			return SpectrumBlocks.ROTTEN_GROUND.getDefaultState();
+		} else if (otherState.isIn(SpectrumFluidTags.MIDNIGHT_SOLUTION)) {
+			return SpectrumBlocks.BLACK_SLUDGE.getDefaultState();
 		}
-		return true;
-	}
-	
-	private void playExtinguishSound(WorldAccess world, BlockPos pos) {
-		world.syncWorldEvent(WorldEvents.LAVA_EXTINGUISHED, pos, 0);
+		return null;
 	}
 	
 }

--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/DragonrotFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/DragonrotFluidBlock.java
@@ -11,6 +11,7 @@ import net.minecraft.util.*;
 import net.minecraft.util.math.*;
 import net.minecraft.util.math.random.*;
 import net.minecraft.world.*;
+import org.jetbrains.annotations.Nullable;
 
 public class DragonrotFluidBlock extends SpectrumFluidBlock {
 	
@@ -41,7 +42,7 @@ public class DragonrotFluidBlock extends SpectrumFluidBlock {
 		return false;
 	}
 
-	public BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
+	public @Nullable BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
 		if (otherState.isIn(FluidTags.WATER)) {
 			return SpectrumBlocks.SLUSH.getDefaultState();
 		} else if (otherState.isIn(FluidTags.LAVA)) {

--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/LiquidCrystalFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/LiquidCrystalFluidBlock.java
@@ -11,6 +11,7 @@ import net.minecraft.util.*;
 import net.minecraft.util.math.*;
 import net.minecraft.util.math.random.*;
 import net.minecraft.world.*;
+import org.jetbrains.annotations.Nullable;
 
 public class LiquidCrystalFluidBlock extends SpectrumFluidBlock {
 	
@@ -43,7 +44,7 @@ public class LiquidCrystalFluidBlock extends SpectrumFluidBlock {
 		}
 	}
 
-	public BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
+	public @Nullable BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
 		if (otherState.isIn(FluidTags.WATER)) {
 			return state.isStill() ? SpectrumBlocks.FROSTBITE_CRYSTAL.getDefaultState() : Blocks.CALCITE.getDefaultState();
 		}

--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/LiquidCrystalFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/LiquidCrystalFluidBlock.java
@@ -4,6 +4,7 @@ import de.dafuqs.spectrum.particle.*;
 import de.dafuqs.spectrum.registries.*;
 import net.minecraft.block.*;
 import net.minecraft.entity.ai.pathing.*;
+import net.minecraft.fluid.FluidState;
 import net.minecraft.particle.*;
 import net.minecraft.registry.tag.*;
 import net.minecraft.util.*;
@@ -41,44 +42,18 @@ public class LiquidCrystalFluidBlock extends SpectrumFluidBlock {
 			world.addParticle(SpectrumParticleTypes.LIQUID_CRYSTAL_SPARKLE, pos.getX() + random.nextDouble(), pos.getY() + random.nextDouble(), pos.getZ() + random.nextDouble(), 0, random.nextDouble() * 0.1, 0);
 		}
 	}
-	
-	/**
-	 * @param world The world
-	 * @param pos   The position in the world
-	 * @param state BlockState of the liquid crystal. Included the height/fluid level
-	 * @return Dunno, actually. I just mod things.
-	 */
-	public boolean receiveNeighborFluids(World world, BlockPos pos, BlockState state) {
-		for (Direction direction : Direction.values()) {
-			BlockPos blockPos = pos.offset(direction);
-			if (world.getFluidState(blockPos).isIn(FluidTags.WATER)) {
-				Block block = world.getFluidState(pos).isStill() ? SpectrumBlocks.FROSTBITE_CRYSTAL : Blocks.CALCITE;
-				world.setBlockState(pos, block.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			}
-			if (world.getFluidState(blockPos).isIn(FluidTags.LAVA)) {
-				Block block;
-				if (world.getFluidState(pos).isStill()) {
-					block = SpectrumBlocks.BLAZING_CRYSTAL;
-				} else {
-					block = Blocks.COBBLED_DEEPSLATE;
-				}
-				world.setBlockState(pos, block.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			}
-			if (world.getFluidState(blockPos).isIn(SpectrumFluidTags.MUD)) {
-				world.setBlockState(pos, Blocks.CLAY.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			}
+
+	public BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
+		if (otherState.isIn(FluidTags.WATER)) {
+			return state.isStill() ? SpectrumBlocks.FROSTBITE_CRYSTAL.getDefaultState() : Blocks.CALCITE.getDefaultState();
 		}
-		return true;
-	}
-	
-	private void playExtinguishSound(WorldAccess world, BlockPos pos) {
-		world.syncWorldEvent(WorldEvents.LAVA_EXTINGUISHED, pos, 0);
+		else if (otherState.isIn(FluidTags.LAVA)) {
+			return state.isStill() ? SpectrumBlocks.BLAZING_CRYSTAL.getDefaultState() : Blocks.COBBLED_DEEPSLATE.getDefaultState();
+		}
+		else if (otherState.isIn(SpectrumFluidTags.MUD)) {
+			return Blocks.CLAY.getDefaultState();
+		}
+		return null;
 	}
 	
 }

--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/MidnightSolutionFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/MidnightSolutionFluidBlock.java
@@ -60,38 +60,50 @@ public class MidnightSolutionFluidBlock extends SpectrumFluidBlock {
 		return false;
 	}
 
-	/**
-	 * @param world The world
-	 * @param pos   The position in the world
-	 * @param state BlockState of the midnight solution. Included the height/fluid level
-	 * @return Dunno, actually. I just mod things.
-	 */
+	@Override
 	public boolean receiveNeighborFluids(World world, BlockPos pos, BlockState state) {
+		// Shouldn't happen but check anyway
+		// If it IS true then do nothing, since no interaction can take place at this position
+		final FluidState fluidState = state.getFluidState();
+		if (fluidState == null || fluidState.isEmpty()) return true;
+
 		for (Direction direction : Direction.values()) {
 			BlockPos neighborPos = pos.offset(direction);
 			FluidState neighborFluidState = world.getFluidState(neighborPos);
-			if (neighborFluidState.isIn(FluidTags.LAVA)) {
-				world.setBlockState(pos, Blocks.TERRACOTTA.getDefaultState());
-				playExtinguishSound(world, pos);
+
+			// Do nothing if neighbor fluid state is empty. [matters for both collision and spread]
+			if (neighborFluidState == null || neighborFluidState.isEmpty()) continue;
+
+			// Fluid collision interaction
+			final BlockState setState = handleFluidCollision(world, fluidState, neighborFluidState);
+			if (setState != null) {
+				fireExtinguishEvent(world, pos);
+				world.setBlockState(pos, setState);
 				return false;
 			}
 
+			// World interaction
 			boolean isNeighborFluidBlock = world.getBlockState(neighborPos).getBlock() instanceof FluidBlock;
 			// spread to the fluid
 			boolean doesTickEntities = world.getWorldChunk(pos).getLevelType().isAfter(ChunkLevelType.ENTITY_TICKING);
 			if (!neighborFluidState.isEmpty() && doesTickEntities) {
 				if (!isNeighborFluidBlock) {
 					world.setBlockState(pos, SPREAD_BLOCKSTATE);
-					playExtinguishSound(world, pos);
+					fireExtinguishEvent(world, pos);
 				} else {
 					if (!neighborFluidState.isOf(this.fluid) && !neighborFluidState.isIn(SpectrumFluidTags.MIDNIGHT_SOLUTION_CONVERTED) && !world.getBlockState(neighborPos).isOf(this)) {
 						world.setBlockState(pos, SPREAD_BLOCKSTATE);
-						playExtinguishSound(world, neighborPos);
+						fireExtinguishEvent(world, neighborPos);
 					}
 				}
 			}
 		}
 		return true;
+	}
+
+	public BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
+		if (otherState.isIn(FluidTags.LAVA)) return Blocks.TERRACOTTA.getDefaultState();
+		return null;
 	}
 
 }

--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/MidnightSolutionFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/MidnightSolutionFluidBlock.java
@@ -101,7 +101,7 @@ public class MidnightSolutionFluidBlock extends SpectrumFluidBlock {
 		return true;
 	}
 
-	public BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
+	public @Nullable BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
 		if (otherState.isIn(FluidTags.LAVA)) return Blocks.TERRACOTTA.getDefaultState();
 		return null;
 	}

--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/MudFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/MudFluidBlock.java
@@ -3,6 +3,7 @@ package de.dafuqs.spectrum.blocks.fluid;
 import de.dafuqs.spectrum.particle.*;
 import net.minecraft.block.*;
 import net.minecraft.entity.ai.pathing.*;
+import net.minecraft.fluid.FluidState;
 import net.minecraft.particle.*;
 import net.minecraft.registry.tag.*;
 import net.minecraft.util.*;
@@ -25,7 +26,7 @@ public class MudFluidBlock extends SpectrumFluidBlock {
 	public Pair<DefaultParticleType, DefaultParticleType> getFishingParticles() {
 		return new Pair<>(SpectrumParticleTypes.MUD_POP, SpectrumParticleTypes.MUD_FISHING);
 	}
-	
+
 	@Override
 	public void randomDisplayTick(BlockState state, World world, BlockPos pos, Random random) {
 		super.randomDisplayTick(state, world, pos, random);
@@ -38,32 +39,16 @@ public class MudFluidBlock extends SpectrumFluidBlock {
 	public boolean canPathfindThrough(BlockState state, BlockView world, BlockPos pos, NavigationType type) {
 		return true;
 	}
-	
-	/**
-	 * @param world The world
-	 * @param pos   The position in the world
-	 * @param state BlockState of the mud. Included the height/fluid level
-	 * @return Dunno, actually. I just mod things.
-	 */
-	public boolean receiveNeighborFluids(World world, BlockPos pos, BlockState state) {
-		for (Direction direction : Direction.values()) {
-			BlockPos blockPos = pos.offset(direction);
-			if (world.getFluidState(blockPos).isIn(FluidTags.WATER)) {
-				world.setBlockState(pos, Blocks.DIRT.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			}
-			if (world.getFluidState(blockPos).isIn(FluidTags.LAVA)) {
-				world.setBlockState(pos, Blocks.COARSE_DIRT.getDefaultState());
-				this.playExtinguishSound(world, pos);
-				return false;
-			}
+
+	@Override
+	public BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
+		if (otherState.isIn(FluidTags.WATER)) {
+			return Blocks.DIRT.getDefaultState();
 		}
-		return true;
-	}
-	
-	private void playExtinguishSound(WorldAccess world, BlockPos pos) {
-		world.syncWorldEvent(WorldEvents.LAVA_EXTINGUISHED, pos, 0);
+		if (otherState.isIn(FluidTags.LAVA)) {
+			return Blocks.COARSE_DIRT.getDefaultState();
+		}
+		return null;
 	}
 	
 }

--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/MudFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/MudFluidBlock.java
@@ -10,6 +10,7 @@ import net.minecraft.util.*;
 import net.minecraft.util.math.*;
 import net.minecraft.util.math.random.*;
 import net.minecraft.world.*;
+import org.jetbrains.annotations.Nullable;
 
 public class MudFluidBlock extends SpectrumFluidBlock {
 	
@@ -40,8 +41,7 @@ public class MudFluidBlock extends SpectrumFluidBlock {
 		return true;
 	}
 
-	@Override
-	public BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
+	public @Nullable BlockState handleFluidCollision(World world, FluidState state, FluidState otherState) {
 		if (otherState.isIn(FluidTags.WATER)) {
 			return Blocks.DIRT.getDefaultState();
 		}

--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/SpectrumFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/SpectrumFluidBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.sound.*;
 import net.minecraft.util.*;
 import net.minecraft.util.math.*;
 import net.minecraft.world.*;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class SpectrumFluidBlock extends FluidBlock {
 	
@@ -64,10 +65,10 @@ public abstract class SpectrumFluidBlock extends FluidBlock {
 	 * @param world The world, because why not?
 	 * @param state FluidState of this fluid.
 	 * @param otherState FluidState of the other fluid.
-	 * @return BlockState to be placed at the collision position.
+	 * @return BlockState to be placed at the collision position. [null means no collision]
 	 * @implNote Triggers the extinguish sound if result is not null.
 	 */
-	public abstract BlockState handleFluidCollision(World world, FluidState state, FluidState otherState);
+	public abstract @Nullable BlockState handleFluidCollision(World world, FluidState state, FluidState otherState);
 
 	public void fireExtinguishEvent(WorldAccess world, BlockPos pos) {
 		world.syncWorldEvent(WorldEvents.LAVA_EXTINGUISHED, pos, 0);


### PR DESCRIPTION
Genericized neighbor update behavior in favor of fluids that only do fluid collision. The only behavior override is for midnight solution, which spreads black materia to blocks in addition to fluid collision.

The refactor was done with mod compatibility purposes in mind, since I have noticed that certain mods have extendable fluid collision handlers which handle fluid collision themselves (for e.g. collision simulation).