### PR TITLE
Use version numbers for Modrinth imports wherever applicable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ dependencies {
 	implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:${project.mixin_extras_version}"))
 
 	// Connect to local dev servers
-	modLocalRuntime("curse.maven:authme-356643:4629826")
+	modLocalRuntime("maven.modrinth:auth-me:7.0.2+1.20")
 
 	// Mod Compat
 	modCompileOnly("maven.modrinth:colorful-hearts:${project.colorful_hearts_version}") { transitive = false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,9 +27,9 @@ trinkets_version=3.7.1
 # https://github.com/emilyploszaj/step-height-entity-attribute
 step_height_attribute_version=1.2.0
 cca_version=5.2.1
-additional_entity_attributes_version=FULyznlV
-revelationary_version=MlH70513
-fractal_version=rBFEjAiy
+additional_entity_attributes_version=1.7.4+1.20.0
+revelationary_version=1.3.8+1.20.1
+fractal_version=1.2.0
 matchbooks_version=1.20-SNAPSHOT
 # https://github.com/JamiesWhiteShirt/reach-entity-attributes
 reach_entity_attributes_version=2.4.0
@@ -38,7 +38,7 @@ mixin_extras_version=0.3.5
 # https://github.com/Terrails/colorful-hearts
 colorful_hearts_version=4.0.4
 # https://modrinth.com/mod/sodium
-sodium_version=dEpHs0Hg
+sodium_version=mc1.20.1-0.5.10
 dimensional_reverb_version=26b0822932
 # https://github.com/Patbox/common-protection-api
 cpa_version=1.0.0
@@ -50,7 +50,7 @@ idwtialsimmoedm_version=0.3.0+1.20
 # https://modrinth.com/mod/travelersbackpack/
 travelers_backpack_version=xa2rNDt3
 # https://modrinth.com/mod/botania/
-botania_version=Qw2uFPdO
+botania_version=1.20.1-444-fabric
 
 # What recipe viewer to use ('emi', 'rei', or 'disabled')
 recipe_viewer=emi


### PR DESCRIPTION
Replaces version IDs with version numbers.
The version of Traveler's Backpack was not changed, since the mod uses the same version number for its Fabric and Forge versions, which confuses Modrinth Maven.