### PR TITLE
Bundle block storage fixup

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleBlock.java
@@ -58,7 +58,7 @@ public class BottomlessBundleBlock extends BlockWithEntity {
 				world.getBlockEntity(pos, SpectrumBlockEntities.BOTTOMLESS_BUNDLE).ifPresent((bottomlessBundleBlockEntity) -> {
 					long amount = bottomlessBundleBlockEntity.storage.amount;
 					ItemVariant variant = bottomlessBundleBlockEntity.storage.getResource();
-					long maxStoredAmount = BottomlessBundleItem.getMaxStoredAmount(bottomlessBundleBlockEntity.bottomlessBundleStack);
+					long maxStoredAmount = BottomlessBundleItem.getMaxStoredAmount(bottomlessBundleBlockEntity.powerLevel);
 					player.sendMessage(Text.translatable("item.spectrum.bottomless_bundle.tooltip.count_of", amount, maxStoredAmount).append(variant.getItem().getName()), true);
 				});
 			} else {

--- a/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
@@ -51,8 +51,13 @@ public class BottomlessBundleItem extends BundleItem implements InventoryInserti
 		return bottomlessBundleStack;
 	}
 
+	// NOTE: this method will become problematic in later versions (1.21)
 	public static int getMaxStoredAmount(ItemStack itemStack) {
 		int powerLevel = EnchantmentHelper.getLevel(Enchantments.POWER, itemStack);
+		return getMaxStoredAmount(powerLevel);
+	}
+
+	public static int getMaxStoredAmount(int powerLevel) {
 		return MAX_STORED_AMOUNT_BASE * (int) Math.pow(10, Math.min(5, powerLevel)); // to not exceed int max
 	}
 

--- a/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
@@ -52,6 +52,7 @@ public class BottomlessBundleItem extends BundleItem implements InventoryInserti
 	}
 
 	// NOTE: this method will become problematic in later versions (1.21)
+	@Deprecated
 	public static int getMaxStoredAmount(ItemStack itemStack) {
 		int powerLevel = EnchantmentHelper.getLevel(Enchantments.POWER, itemStack);
 		return getMaxStoredAmount(powerLevel);


### PR DESCRIPTION
Storage operations now manipulate internal storage state directly. Bundle contents and storage data are now synced with each other whenever needed.

Tested using a simple hopper setup (item insertion, item extraction, block break mid-transfer). The sum amount of extracted items and items within the bundle match the amount of inserted items.