### PR TITLE
You know how ghasts don't spawn ever

### DIFF
--- a/src/main/resources/data/spectrum/modonomicon/books/guidebook/entries/creating_life/creature_manipulation.json
+++ b/src/main/resources/data/spectrum/modonomicon/books/guidebook/entries/creating_life/creature_manipulation.json
@@ -52,6 +52,10 @@
     },
     {
       "type": "spectrum:spirit_instiller_crafting",
+      "recipe_id_1": "spectrum:spirit_instiller/head_fusion/ghast"
+    },
+    {
+      "type": "spectrum:spirit_instiller_crafting",
       "recipe_id_1": "spectrum:spirit_instiller/head_fusion/wither_skeleton"
     },
     {

--- a/src/main/resources/data/spectrum/recipes/spirit_instiller/head_fusion/ghast.json
+++ b/src/main/resources/data/spectrum/recipes/spirit_instiller/head_fusion/ghast.json
@@ -1,0 +1,21 @@
+{
+  "type": "spectrum:spirit_instiller",
+  "group": "head_fusion",
+  "time": 800,
+  "experience": 4.0,
+  "ingredient1": {
+    "item": "spectrum:phantom_head"
+  },
+  "ingredient2": {
+    "item": "minecraft:soul_sand",
+    "count": 4
+  },
+  "center_ingredient": {
+    "item": "spectrum:vegetal",
+    "count": 4
+  },
+  "result": {
+    "item": "spectrum:ghast_head"
+  },
+  "required_advancement": "spectrum:unlocks/head_fusion"
+}

--- a/src/main/resources/data/spectrum/recipes/spirit_instiller/memories/ghast.json
+++ b/src/main/resources/data/spectrum/recipes/spirit_instiller/memories/ghast.json
@@ -7,7 +7,7 @@
     "item": "spectrum:ghast_head"
   },
   "ingredient2": {
-    "item": "minecraft:ghast_tear"
+    "item": "minecraft:phantom_membrane"
   },
   "center_ingredient": {
     "tag": "spectrum:memory_bonding_agents",


### PR DESCRIPTION
Adds a new head fusion recipe to create ghast heads because holy fuck finding them sucks. Also changes their head→memory recipe because why do they require one of their own drops that doesn't even always drop to be made into a memory that defeats the entire purpose.