### PR TITLE
Add crushing recipes for turning clovers into Green dye

### DIFF
--- a/src/main/resources/data/spectrum/recipes/anvil_crushing/dye/green_dye_from_clover
+++ b/src/main/resources/data/spectrum/recipes/anvil_crushing/dye/green_dye_from_clover
@@ -1,0 +1,14 @@
+{
+  "type": "spectrum:anvil_crushing",
+  "ingredient": {
+    "item": "spectrum:clover"
+  },
+  "crushedItemsPerPointOfDamage": 2,
+  "experience": 0.0,
+  "result": {
+    "item": "minecraft:green_dye",
+    "count": 1
+  },
+  "particleEffectIdentifier": "cloud",
+  "soundEventIdentifier": "block.grass.break"
+}

--- a/src/main/resources/data/spectrum/recipes/anvil_crushing/dye/green_dye_from_four_leaf_clover
+++ b/src/main/resources/data/spectrum/recipes/anvil_crushing/dye/green_dye_from_four_leaf_clover
@@ -1,0 +1,15 @@
+{
+  "type": "spectrum:anvil_crushing",
+  "ingredient": {
+    "item": "spectrum:four_leaf_clover"
+  },
+  "crushedItemsPerPointOfDamage": 1,
+  "experience": 0.8,
+  "result": {
+    "item": "minecraft:green_dye",
+    "count": 4
+  },
+  "particleEffectIdentifier": "cloud",
+  "soundEventIdentifier": "block.grass.break",
+  "required_advancement": "spectrum:collect_four_leaf_clover"
+}


### PR DESCRIPTION
I would _like_ for doing this with a regular clover to only have a percentage chance of giving you dye, due to the abundance of clovers, but sadly this recipe type does not support chanced outputs. 
Crushing a four leaf clover gives a lot more dye, and additionally a decent amount of XP.