### PR TITLE
Resonant Pickaxes aren't crafted with paltaeria anymore

### DIFF
--- a/src/main/resources/data/spectrum/advancements/lategame/craft_resonant_pickaxe.json
+++ b/src/main/resources/data/spectrum/advancements/lategame/craft_resonant_pickaxe.json
@@ -26,7 +26,7 @@
     },
     "gotten_previous": {
       "trigger":"revelationary:advancement_gotten",
-      "conditions": { "advancement_identifier": "spectrum:lategame/collect_paltaeria" }
+      "conditions": { "advancement_identifier": "spectrum:lategame/build_complex_pedestal_structure" }
     }
   }
 }


### PR DESCRIPTION
Fix the advancement unlock to no longer require palt