### PR TITLE
Add mod compat recipe for Supplementaries Stasis Books

### DIFF
--- a/src/main/resources/data/spectrum/recipes/mod_integration/supplementaries/enchanter/book_stasis.json
+++ b/src/main/resources/data/spectrum/recipes/mod_integration/supplementaries/enchanter/book_stasis.json
@@ -1,0 +1,54 @@
+{
+  "type": "spectrum:enchanter",
+  "time": 1200,
+  "required_experience": 500,
+  "ingredients": [
+    {
+      "item": "minecraft:book"
+    },
+    {
+      "item": "spectrum:light_gray_pigment"
+    },
+    {
+      "item": "spectrum:light_gray_pigment"
+    },
+    {
+      "item": "spectrum:stratine_fragments"
+    },
+    {
+      "item": "spectrum:paltaeria_fragments"
+    },
+    {
+      "item": "spectrum:light_gray_pigment"
+    },
+    {
+      "item": "spectrum:light_gray_pigment"
+    },
+    {
+      "item": "spectrum:stratine_fragments"
+    },
+    {
+      "item": "spectrum:paltaeria_fragments"
+    }
+  ],
+  "result": {
+    "item": "minecraft:enchanted_book",
+    "nbt": {
+      "StoredEnchantments": [
+        {
+          "id": "supplementaries:stasis",
+          "lvl": "1s"
+        }
+      ]
+    }
+  },
+  "required_advancement": "spectrum:unlocks/enchantments/vanilla_treasure",
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "supplementaries"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Soap's been awfully mean to us, so we should appease it by implementing compat for the bubble blower enchant.
This will clearly make soap not cause more issues with turning things white, right?


I was a bit unsure whether to make this require blue ink and gems, or light gray and fragments like the vanilla treasure enchants. I've settled on it being the same structure as frost walker/mending, but i'm open to changing this. The stratine and palt balance each other out, creating a similar "stasis" effect as hoverblocks