### PR TITLE
fixed incorrect sound id

### DIFF
--- a/src/main/resources/data/spectrum/worldgen/biome/black_langast.json
+++ b/src/main/resources/data/spectrum/worldgen/biome/black_langast.json
@@ -17,7 +17,7 @@
       "offset": 2
     },
     "music": {
-      "sound": "spectrum:music.deeper_down_theme",
+      "sound": "spectrum:music.deeper_down",
       "min_delay": 12000,
       "max_delay": 24000,
       "replace_current_music": false

--- a/src/main/resources/data/spectrum/worldgen/biome/crystal_gardens.json
+++ b/src/main/resources/data/spectrum/worldgen/biome/crystal_gardens.json
@@ -23,7 +23,7 @@
       "offset": 2
     },
     "music": {
-      "sound": "spectrum:music.deeper_down_theme",
+      "sound": "spectrum:music.deeper_down",
       "min_delay": 12000,
       "max_delay": 24000,
       "replace_current_music": false

--- a/src/main/resources/data/spectrum/worldgen/biome/deep_barrens.json
+++ b/src/main/resources/data/spectrum/worldgen/biome/deep_barrens.json
@@ -17,7 +17,7 @@
       "offset": 2
     },
     "music": {
-      "sound": "spectrum:music.deeper_down_theme",
+      "sound": "spectrum:music.deeper_down",
       "min_delay": 12000,
       "max_delay": 24000,
       "replace_current_music": false

--- a/src/main/resources/data/spectrum/worldgen/biome/deep_dripstone_caves.json
+++ b/src/main/resources/data/spectrum/worldgen/biome/deep_dripstone_caves.json
@@ -23,7 +23,7 @@
       "offset": 2
     },
     "music": {
-      "sound": "spectrum:music.deeper_down_theme",
+      "sound": "spectrum:music.deeper_down",
       "min_delay": 12000,
       "max_delay": 24000,
       "replace_current_music": false

--- a/src/main/resources/data/spectrum/worldgen/biome/dragonrot_swamp.json
+++ b/src/main/resources/data/spectrum/worldgen/biome/dragonrot_swamp.json
@@ -23,7 +23,7 @@
       "probability": 0.0255
     },
     "music": {
-      "sound": "spectrum:music.deeper_down_theme",
+      "sound": "spectrum:music.deeper_down",
       "min_delay": 12000,
       "max_delay": 24000,
       "replace_current_music": false

--- a/src/main/resources/data/spectrum/worldgen/biome/howling_spires.json
+++ b/src/main/resources/data/spectrum/worldgen/biome/howling_spires.json
@@ -17,7 +17,7 @@
       "offset": 2
     },
     "music": {
-      "sound": "spectrum:music.deeper_down_theme",
+      "sound": "spectrum:music.deeper_down",
       "min_delay": 12000,
       "max_delay": 24000,
       "replace_current_music": false

--- a/src/main/resources/data/spectrum/worldgen/biome/noxshroom_forest.json
+++ b/src/main/resources/data/spectrum/worldgen/biome/noxshroom_forest.json
@@ -23,7 +23,7 @@
       "offset": 2
     },
     "music": {
-      "sound": "spectrum:music.deeper_down_theme",
+      "sound": "spectrum:music.deeper_down",
       "min_delay": 12000,
       "max_delay": 24000,
       "replace_current_music": false

--- a/src/main/resources/data/spectrum/worldgen/biome/razor_edge.json
+++ b/src/main/resources/data/spectrum/worldgen/biome/razor_edge.json
@@ -23,7 +23,7 @@
       "offset": 2
     },
     "music": {
-      "sound": "spectrum:music.deeper_down_theme",
+      "sound": "spectrum:music.deeper_down",
       "min_delay": 12000,
       "max_delay": 24000,
       "replace_current_music": false


### PR DESCRIPTION
Fixes #484 . The deeper down biome jsons had an invalid sound id, which didn't actually matter since the MinecraftClientMixin overrides the music anyway, but apparently can cause issues if certain mods are present.