### PR TITLE
Add c: tool tags to spectrum items

### DIFF
--- a/src/main/resources/data/c/tags/items/axes.json
+++ b/src/main/resources/data/c/tags/items/axes.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#spectrum:axes"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/hoes.json
+++ b/src/main/resources/data/c/tags/items/hoes.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#spectrum:hoes"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/pickaxes.json
+++ b/src/main/resources/data/c/tags/items/pickaxes.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#spectrum:pickaxes"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/shovels.json
+++ b/src/main/resources/data/c/tags/items/shovels.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#spectrum:shovels"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/swords.json
+++ b/src/main/resources/data/c/tags/items/swords.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#spectrum:swords"
+  ]
+}


### PR DESCRIPTION
For SOME reason, there exist #c:axes , which is entirely separate from #minecraft:axes . Some mods are actually using this.
This PR adds these tags to spectrum's tools.