### PR TITLE
Sheep head tag fix

### DIFF
--- a/src/main/resources/data/spectrum/recipes/fusion_shrine/egg_laying_wooly_pig_head.json
+++ b/src/main/resources/data/spectrum/recipes/fusion_shrine/egg_laying_wooly_pig_head.json
@@ -10,7 +10,7 @@
       "item": "spectrum:cow_head"
     },
     {
-      "tag": "spectrum:sheep_head"
+      "item": "spectrum:sheep_head"
     },
     {
       "item": "spectrum:pig_head"

--- a/src/main/resources/data/spectrum/recipes/fusion_shrine/egg_laying_wooly_pig_head.json
+++ b/src/main/resources/data/spectrum/recipes/fusion_shrine/egg_laying_wooly_pig_head.json
@@ -10,7 +10,7 @@
       "item": "spectrum:cow_head"
     },
     {
-      "tag": "spectrum:mob_heads/sheep_heads"
+      "tag": "spectrum:sheep_head"
     },
     {
       "item": "spectrum:pig_head"

--- a/src/main/resources/data/spectrum/recipes/pedestal/tier3/idols/sheep.json
+++ b/src/main/resources/data/spectrum/recipes/pedestal/tier3/idols/sheep.json
@@ -16,7 +16,7 @@
   ],
   "key": {
     "H": {
-      "tag": "spectrum:mob_heads/sheep_heads"
+      "item": "spectrum:sheep_head"
     },
     "V": {
       "item": "spectrum:vegetal"


### PR DESCRIPTION
Sheep heads were changed from multiple colored items into one item in 73eb6a722dec1cc0c520e88f1d95e44a22162fa9, but the recipe for the Devout Idol and Egg Laying Wooly Pig Head still use the invalid tag; this PR fixes this