### PR TITLE
Fix always crit mixin

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/mixin/PlayerEntityMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/PlayerEntityMixin.java
@@ -129,7 +129,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
 		return original;
 	}
 
-	@ModifyVariable(method = "attack", at = @At(value = "STORE:LAST"), index = 8, require = 1, allow = 1)
+	@ModifyVariable(method = "attack", at = @At(value = "STORE"), index = 8, require = 1)
 	private boolean spectrum$binglebongle(boolean value, Entity target) {
 		if (hasForcedCrits(target)) {
 			return true;


### PR DESCRIPTION
This fixes a bug when using Spectrum 1.8.0-alpha4 with Connector. Here is the relevant crashlog:

```
Prism Launcher version: 8.4 (archlinux)


Launched instance in online mode

login.microsoftonline.com resolves to:
    [20.190.177.83, 20.190.177.23, 20.190.147.4, 20.190.177.85, 20.190.177.84, 20.190.147.8, 20.190.147.12, 20.190.177.147, 2603:1027:1:28::20, 2603:1027:1:28::1d, 2603:1027:1:28::a, 2603:1027:1:28::4, 2603:1027:1:28::1e, 2603:1027:1:28::12, 2603:1027:1:28::25, 2603:1027:1:28::d]

session.minecraft.net resolves to:
    [13.107.246.53, 2620:1ec:bdf::53]

textures.minecraft.net resolves to:
    [13.107.246.53, 2620:1ec:bdf::53]

api.mojang.com resolves to:
    [13.107.246.53, 2620:1ec:bdf::53]


Minecraft folder is:
/home/saoirse/.local/share/PrismLauncher/instances/connector16/.minecraft


Java path is:
/usr/lib/jvm/java-17-openjdk/bin/java


Java is version 17.0.13, using 64 (amd64) architecture, from Arch Linux.


11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz
Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] (rev 01)

Subsystem: Microsoft Corporation Device 0045

Kernel driver in use: i915

Main Class:
  io.github.zekerzhayard.forgewrapper.installer.Main

Native path:
  /home/saoirse/.local/share/PrismLauncher/instances/connector16/natives

Traits:
traits feature:is_quick_play_multiplayer
traits XR:Initial
traits FirstThreadOnMacOS
traits feature:is_quick_play_singleplayer

Libraries:
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-glfw-natives-linux/3.3.2-lwjgl.1/lwjgl-glfw-natives-linux-3.3.2-lwjgl.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-jemalloc-natives-linux/3.3.1/lwjgl-jemalloc-natives-linux-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-natives-linux/3.3.1/lwjgl-natives-linux-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-openal-natives-linux/3.3.1/lwjgl-openal-natives-linux-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-opengl-natives-linux/3.3.1/lwjgl-opengl-natives-linux-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-stb-natives-linux/3.3.1/lwjgl-stb-natives-linux-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-tinyfd-natives-linux/3.3.1/lwjgl-tinyfd-natives-linux-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/github/oshi/oshi-core/6.2.2/oshi-core-6.2.2.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/google/code/gson/gson/2.10/gson-2.10.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/ibm/icu/icu4j/71.1/icu4j-71.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/mojang/authlib/4.0.43/authlib-4.0.43.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/mojang/blocklist/1.0.10/blocklist-1.0.10.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/mojang/brigadier/1.1.8/brigadier-1.1.8.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/mojang/datafixerupper/6.0.8/datafixerupper-6.0.8.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/mojang/logging/1.1.1/logging-1.1.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/mojang/patchy/2.2.10/patchy-2.2.10.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/mojang/text2speech/1.17.9/text2speech-1.17.9.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/commons-codec/commons-codec/1.15/commons-codec-1.15.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-buffer/4.1.82.Final/netty-buffer-4.1.82.Final.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-codec/4.1.82.Final/netty-codec-4.1.82.Final.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-common/4.1.82.Final/netty-common-4.1.82.Final.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-handler/4.1.82.Final/netty-handler-4.1.82.Final.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-resolver/4.1.82.Final/netty-resolver-4.1.82.Final.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-transport-classes-epoll/4.1.82.Final/netty-transport-classes-epoll-4.1.82.Final.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-transport-native-epoll/4.1.82.Final/netty-transport-native-epoll-4.1.82.Final-linux-aarch_64.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-transport-native-epoll/4.1.82.Final/netty-transport-native-epoll-4.1.82.Final-linux-x86_64.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-transport-native-unix-common/4.1.82.Final/netty-transport-native-unix-common-4.1.82.Final.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/netty/netty-transport/4.1.82.Final/netty-transport-4.1.82.Final.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/it/unimi/dsi/fastutil/8.5.9/fastutil-8.5.9.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/java/dev/jna/jna-platform/5.12.1/jna-platform-5.12.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/apache/logging/log4j/log4j-api/2.19.0/log4j-api-2.19.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/apache/logging/log4j/log4j-core/2.19.0/log4j-core-2.19.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/apache/logging/log4j/log4j-slf4j2-impl/2.19.0/log4j-slf4j2-impl-2.19.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/joml/joml/1.10.5/joml-1.10.5.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/slf4j/slf4j-api/2.0.1/slf4j-api-2.0.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/io/github/zekerzhayard/ForgeWrapper/prism-2024-02-29/ForgeWrapper-prism-2024-02-29.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/cpw/mods/securejarhandler/2.1.10/securejarhandler-2.1.10.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/ow2/asm/asm/9.7/asm-9.7.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/ow2/asm/asm-commons/9.7/asm-commons-9.7.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/ow2/asm/asm-tree/9.7/asm-tree-9.7.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/ow2/asm/asm-util/9.7/asm-util-9.7.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/ow2/asm/asm-analysis/9.7/asm-analysis-9.7.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/accesstransformers/8.0.4/accesstransformers-8.0.4.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/antlr/antlr4-runtime/4.9.1/antlr4-runtime-4.9.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/eventbus/6.0.5/eventbus-6.0.5.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/forgespi/7.0.1/forgespi-7.0.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/coremods/5.1.6/coremods-5.1.6.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/cpw/mods/modlauncher/10.0.9/modlauncher-10.0.9.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/unsafe/0.2.0/unsafe-0.2.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/mergetool/1.1.5/mergetool-1.1.5-api.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/electronwill/night-config/core/3.6.4/core-3.6.4.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/electronwill/night-config/toml/3.6.4/toml-3.6.4.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/apache/maven/maven-artifact/3.8.5/maven-artifact-3.8.5.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/jodah/typetools/0.6.3/typetools-0.6.3.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecrell/terminalconsoleappender/1.2.0/terminalconsoleappender-1.2.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/jline/jline-reader/3.12.1/jline-reader-3.12.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/jline/jline-terminal/3.12.1/jline-terminal-3.12.1.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/spongepowered/mixin/0.8.5/mixin-0.8.5.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/org/openjdk/nashorn/nashorn-core/15.3/nashorn-core-15.3.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/JarJarSelector/0.3.19/JarJarSelector-0.3.19.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/JarJarMetadata/0.3.19/JarJarMetadata-0.3.19.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/cpw/mods/bootstraplauncher/1.1.2/bootstraplauncher-1.1.2.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/JarJarFileSystems/0.3.19/JarJarFileSystems-0.3.19.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/fmlloader/1.20.1-47.3.0/fmlloader-1.20.1-47.3.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/fmlearlydisplay/1.20.1-47.3.0/fmlearlydisplay-1.20.1-47.3.0.jar
  /home/saoirse/.local/share/PrismLauncher/libraries/com/mojang/minecraft/1.20.1/minecraft-1.20.1-client.jar

Native libraries:

Mods:
  [✘] appleskin-forge-mc1.20.1-2.5.1.jar (disabled)
  [✘] BadOptimizations-2.2.0-1.20.1.jar (disabled)
  [✘] badpackets-forge-0.4.3.jar (disabled)
  [✔] cloth-config-11.1.136-forge
  [✔] Connector-1.0.0-beta.46+1.20.1
  [✔] ConnectorExtras-1.11.2+1.20.1
  [✘] create-1.20.1-0.5.1.j.jar (disabled)
  [✘] create-structures-0.1.1-1.20.1-FORGE.jar (disabled)
  [✘] createoreexcavation-1.20-1.5.2.jar (disabled)
  [✘] curios-forge-5.11.0+1.20.1.jar (disabled)
  [✘] deeperdarker-forge-1.20.1-1.3.1.jar (disabled)
  [✘] embeddium-0.3.31+mc1.20.1.jar (disabled)
  [✘] emi-1.1.16+1.20.1+forge.jar (disabled)
  [✘] entityculling-forge-1.7.0-mc1.20.1.jar (disabled)
  [✔] exclusions_lib-0.6
  [✔] fabric-api-0.92.2+1.11.8+1.20.1
  [✘] ferritecore-6.0.1-forge.jar (disabled)
  [✘] fusion-1.1.1-forge-mc1.20.1.jar (disabled)
  [✘] jei-1.20.1-forge-15.20.0.104.jar (disabled)
  [✘] lodestone-1.20.1-1.6.3.jar (disabled)
  [✘] malum-1.20.1-1.6.4.jar (disabled)
  [✘] modernfix-forge-5.19.4+mc1.20.1.jar (disabled)
  [✔] modonomicon-1.20.1-forge-1.77.3
  [✘] NoChatReports-FORGE-1.20.1-v2.2.2.jar (disabled)
  [✘] noisium-forge-2.3.0+mc1.20-1.20.1.jar (disabled)
  [✘] oculus-mc1.20.1-1.7.0.jar (disabled)
  [✔] revelationary-1.3.9+1.20.1
  [✔] spectrum-1.8.0-alpha4
  [✔] trinkets-3.7.2
  [✘] wizards_reborn-1.20.1-0.1.6.jar (disabled)
  [✘] wthit-forge-8.15.2.jar (disabled)

Params:
  --username  --version 1.20.1 --gameDir /home/saoirse/.local/share/PrismLauncher/instances/connector16/.minecraft --assetsDir /home/saoirse/.local/share/PrismLauncher/assets --assetIndex 5 --uuid  --accessToken  --userType  --versionType release --launchTarget forgeclient --fml.forgeVersion 47.3.0 --fml.mcVersion 1.20.1 --fml.forgeGroup net.minecraftforge --fml.mcpVersion 20230612.114412

Window size: 854 x 480

Launcher: standard

Java Arguments:
[-Xms512m, -Xmx4096m, -Duser.language=en]


Minecraft process ID: 40485


Checking: MC_SLIM
Checking: MERGED_MAPPINGS
Checking: MAPPINGS
Checking: MC_EXTRA
Checking: MOJMAPS
Checking: PATCHED
Checking: MC_SRG
2024-10-25 14:00:42,607 main WARN Advanced terminal features are not available in this environment
[14:00:42] [main/INFO] [cp.mo.mo.Launcher/MODLAUNCHER]: ModLauncher running: args [--username, Sjoraet, --version, 1.20.1, --gameDir, /home/saoirse/.local/share/PrismLauncher/instances/connector16/.minecraft, --assetsDir, /home/saoirse/.local/share/PrismLauncher/assets, --assetIndex, 5, --uuid, <PROFILE ID>, --accessToken, ❄❄❄❄❄❄❄❄, --userType, msa, --versionType, release, --launchTarget, forgeclient, --fml.forgeVersion, 47.3.0, --fml.mcVersion, 1.20.1, --fml.forgeGroup, net.minecraftforge, --fml.mcpVersion, 20230612.114412, --width, 854, --height, 480]
[14:00:42] [main/INFO] [cp.mo.mo.Launcher/MODLAUNCHER]: ModLauncher 10.0.9+10.0.9+main.dcd20f30 starting: java version 17.0.13 by Arch Linux; OS Linux arch amd64 version 6.11.4-arch1-1
[14:00:42] [main/INFO] [ne.mi.fm.lo.ImmediateWindowHandler/]: Loading ImmediateWindowProvider fmlearlywindow
[14:00:42] [main/INFO] [EARLYDISPLAY/]: Trying GL version 4.6
[14:00:43] [main/INFO] [EARLYDISPLAY/]: Requested GL version 4.6 got version 4.6
[14:00:43] [main/INFO] [mixin-transmog/]: Mixin Transmogrifier is definitely up to no good...
[14:00:43] [main/INFO] [mixin-transmog/]: crimes against java were committed
[14:00:43] [pool-2-thread-1/INFO] [EARLYDISPLAY/]: GL info: Mesa Intel(R) Xe Graphics (TGL GT2) GL version 4.6 (Core Profile) Mesa 24.2.5-arch1.1, Intel
[14:00:43] [main/INFO] [mixin-transmog/]: Original mixin transformation service successfully crobbed by mixin-transmogrifier!
[14:00:43] [main/INFO] [mixin/]: SpongePowered MIXIN Subsystem Version=0.8.5 Source=union:/home/saoirse/.local/share/PrismLauncher/instances/connector16/.minecraft/mods/Connector-1.0.0-beta.46+1.20.1.jar%23155%23158!/ Service=ModLauncher Env=CLIENT
[14:00:43] [main/WARN] [ne.mi.fm.lo.mo.ModFileParser/LOADING]: Mod file /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/fmlcore/1.20.1-47.3.0/fmlcore-1.20.1-47.3.0.jar is missing mods.toml file
[14:00:43] [main/WARN] [ne.mi.fm.lo.mo.ModFileParser/LOADING]: Mod file /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/javafmllanguage/1.20.1-47.3.0/javafmllanguage-1.20.1-47.3.0.jar is missing mods.toml file
[14:00:43] [main/WARN] [ne.mi.fm.lo.mo.ModFileParser/LOADING]: Mod file /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/lowcodelanguage/1.20.1-47.3.0/lowcodelanguage-1.20.1-47.3.0.jar is missing mods.toml file
[14:00:43] [main/WARN] [ne.mi.fm.lo.mo.ModFileParser/LOADING]: Mod file /home/saoirse/.local/share/PrismLauncher/libraries/net/minecraftforge/mclanguage/1.20.1-47.3.0/mclanguage-1.20.1-47.3.0.jar is missing mods.toml file
[14:00:43] [main/INFO] [ne.mi.fm.lo.mo.JarInJarDependencyLocator/]: Found 64 dependencies adding them to mods collection
[14:00:44] [main/INFO] [or.si.co.lo.DependencyResolver/]: Dependency resolution found 17 candidates to load
[14:00:45] [pool-3-thread-9/WARN] [or.si.co.tr.RefmapRemapper/]: Refmap remapper could not find refmap file matchbooks-refmap.json
[14:00:45] [ForkJoinPool-9-worker-7/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:45] [ForkJoinPool-9-worker-7/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:45] [ForkJoinPool-9-worker-1/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:46] [ForkJoinPool-9-worker-3/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: LOAD injection point must be used in conjunction with @ModifyVariable
[14:00:46] [pool-3-thread-1/INFO] [or.si.co.tr.MixinPatchTransformer/]: Adding 2 mixins to config additionalentityattributes.mixins.json
[14:00:46] [ForkJoinPool-12-worker-3/INFO] [or.si.ad.pa.fi.FieldTypeUsageTransformer/]: Running fixup for field net/minecraft/world/level/storage/loot/LootTable.f_79109_[Lnet/minecraft/world/level/storage/loot/LootPool; in method execute(Lnet/minecraft/commands/CommandSourceStack;Ljava/lang/String;)I
[14:00:47] [ForkJoinPool-12-worker-1/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-1/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-1/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: LOAD injection point must be used in conjunction with @ModifyVariable
org.objectweb.asm.tree.analysis.AnalyzerException: Error at instruction 220: Cannot invoke "org.spongepowered.asm.mixin.transformer.ClassInfo.hasSuperClass(org.spongepowered.asm.mixin.transformer.ClassInfo)" because the return value of "org.spongepowered.asm.mixin.transformer.ClassInfo.forType(org.objectweb.asm.Type, org.spongepowered.asm.mixin.transformer.ClassInfo$TypeLookup)" is null
	at org.objectweb.asm.tree.analysis@9.7/org.objectweb.asm.tree.analysis.Analyzer.analyze(Analyzer.java:288)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.Locals.generateLocalVariableTable(Locals.java:898)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.Locals.getGeneratedLocalVariableTable(Locals.java:867)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.Locals.getLocalVariableAt(Locals.java:821)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.Locals.getLocalVariableAt(Locals.java:791)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.Locals.getLocalsAt(Locals.java:568)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.Locals.getLocalsAt(Locals.java:425)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.Locals.getLocalsAt(Locals.java:343)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.Locals.getLocalsAt(Locals.java:335)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/org.sinytra.adapter.patch.MethodContextImpl.getTargetMethodLocals(MethodContextImpl.java:158)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/org.sinytra.adapter.patch.api.MethodContext.getTargetMethodLocals(MethodContext.java:53)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/org.sinytra.adapter.patch.MethodContextImpl.getTargetMethodLocals(MethodContextImpl.java:143)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/org.sinytra.adapter.patch.transformer.dynamic.DynamicLVTPatch.compareParameters(DynamicLVTPatch.java:160)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/org.sinytra.adapter.patch.transformer.dynamic.DynamicLVTPatch.apply(DynamicLVTPatch.java:86)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/org.sinytra.adapter.patch.PatchInstance.apply(PatchInstance.java:69)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/org.sinytra.connector.transformer.MixinPatchTransformer.process(MixinPatchTransformer.java:219)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/reloc.net.minecraftforge.fart.internal.EntryImpl$ClassEntry.process(EntryImpl.java:58)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/reloc.net.minecraftforge.fart.internal.EntryImpl$ClassEntry.process(EntryImpl.java:36)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/reloc.net.minecraftforge.fart.internal.RenamerImpl.processEntry(RenamerImpl.java:215)
	at LAYER SERVICE/org.sinytra.connector@1.0.0-beta.46+1.20.1/reloc.net.minecraftforge.fart.internal.AsyncHelper.lambda$null$2(AsyncHelper.java:40)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1428)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
Caused by: java.lang.NullPointerException: Cannot invoke "org.spongepowered.asm.mixin.transformer.ClassInfo.hasSuperClass(org.spongepowered.asm.mixin.transformer.ClassInfo)" because the return value of "org.spongepowered.asm.mixin.transformer.ClassInfo.forType(org.objectweb.asm.Type, org.spongepowered.asm.mixin.transformer.ClassInfo$TypeLookup)" is null
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.util.asm.MixinVerifier.isAssignableFrom(MixinVerifier.java:104)
	at org.objectweb.asm.tree.analysis@9.7/org.objectweb.asm.tree.analysis.SimpleVerifier.isSubTypeOf(SimpleVerifier.java:212)
	at org.objectweb.asm.tree.analysis@9.7/org.objectweb.asm.tree.analysis.BasicVerifier.binaryOperation(BasicVerifier.java:300)
	at org.objectweb.asm.tree.analysis@9.7/org.objectweb.asm.tree.analysis.BasicVerifier.binaryOperation(BasicVerifier.java:44)
	at org.objectweb.asm.tree.analysis@9.7/org.objectweb.asm.tree.analysis.Frame.execute(Frame.java:521)
	at org.objectweb.asm.tree.analysis@9.7/org.objectweb.asm.tree.analysis.Analyzer.analyze(Analyzer.java:171)
	... 25 more
[14:00:47] [ForkJoinPool-12-worker-1/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-5/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-5/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-8/INFO] [or.si.ad.pa.tr.dy.DynamicAnonymousShadowFieldTypePatch/]: Renaming anonymous class field de/dafuqs/spectrum/mixin/ServerPlayNetworkHandlerMixin$NetworkEntityValidationMixin.this$0 to f_143671_
[14:00:47] [ForkJoinPool-12-worker-8/INFO] [or.si.ad.pa.tr.dy.DynamicAnonymousShadowFieldTypePatch/]: Renaming anonymous class field de/dafuqs/spectrum/mixin/ServerPlayNetworkHandlerMixin$NetworkEntityValidationMixin.innerEntity to val$entity
[14:00:47] [ForkJoinPool-12-worker-2/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-2/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-2/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-2/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-5/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:47] [ForkJoinPool-12-worker-5/ERROR] [or.si.ad.pa.MethodContextImpl/]: Error finding injection insns: STORE injection point must be used in conjunction with @ModifyVariable
[14:00:50] [pool-3-thread-13/INFO] [or.si.co.tr.MixinPatchTransformer/]: Adding 1 mixins to config spectrum.mixins.json
[14:00:51] [main/INFO] [or.si.co.se.ha.ModuleLayerMigrator/]: Successfully made module authlib transformable
[14:00:51] [main/INFO] [mixin/]: Compatibility level set to JAVA_17
[14:00:51] [main/INFO] [cp.mo.mo.LaunchServiceHandler/MODLAUNCHER]: Launching target 'forgeclient' with arguments [--version, 1.20.1, --gameDir, /home/saoirse/.local/share/PrismLauncher/instances/connector16/.minecraft, --assetsDir, /home/saoirse/.local/share/PrismLauncher/assets, --uuid, <PROFILE ID>, --username, Sjoraet, --assetIndex, 5, --accessToken, ❄❄❄❄❄❄❄❄, --userType, msa, --versionType, release, --width, 854, --height, 480]
[14:00:51] [main/WARN] [mixin/]: Reference map 'matchbooks-refmap.json' for matchbooks.mixins.json could not be read. If this is a development environment you can ignore this message
[14:00:51] [main/WARN] [mixin/]: Reference map 'modonomicon.refmap.json' for modonomicon.mixins.json could not be read. If this is a development environment you can ignore this message
[14:00:51] [main/WARN] [mixin/]: Reference map 'modonomicon.refmap.json' for modonomicon.forge.mixins.json could not be read. If this is a development environment you can ignore this message
[14:00:51] [main/WARN] [mixin/]: Reference map '' for adapter.init.mixins.json could not be read. If this is a development environment you can ignore this message
[14:00:52] [main/INFO] [MixinExtras|Service/]: Initializing MixinExtras via com.llamalad7.mixinextras.service.MixinExtrasServiceImpl(version=0.3.5).
Exception caught from launcher
java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at io.github.zekerzhayard.forgewrapper.installer.Main.main(Main.java:67)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:100)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
Caused by: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:32)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.Launcher.run(Launcher.java:108)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.Launcher.main(Launcher.java:78)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23)
	at cpw.mods.bootstraplauncher@1.1.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:141)
	... 8 more
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.0/net.minecraftforge.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:111)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.0/net.minecraftforge.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:99)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.0/net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$makeService$0(CommonClientLaunchHandler.java:25)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30)
	... 15 more
Caused by: java.lang.RuntimeException: org.spongepowered.asm.mixin.transformer.throwables.MixinTransformerError: An unexpected critical error was encountered
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.0/net.minecraftforge.fml.loading.BackgroundWaiter.runAndTick(BackgroundWaiter.java:32)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.client.main.Main.main(Main.java:151)
	... 23 more
Caused by: org.spongepowered.asm.mixin.transformer.throwables.MixinTransformerError: An unexpected critical error was encountered
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:392)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClass(MixinTransformer.java:250)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.service.modlauncher.MixinTransformationHandler.processClass(MixinTransformationHandler.java:131)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.launch.MixinLaunchPluginLegacy.processClass(MixinLaunchPluginLegacy.java:131)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.serviceapi.ILaunchPluginService.processClassWithFlags(ILaunchPluginService.java:156)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.LaunchPluginHandler.offerClassNodeToPlugins(LaunchPluginHandler.java:88)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.ClassTransformer.transform(ClassTransformer.java:120)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.TransformingClassLoader.maybeTransformClassBytes(TransformingClassLoader.java:50)
	at cpw.mods.securejarhandler/cpw.mods.cl.ModuleClassLoader.readerToClass(ModuleClassLoader.java:113)
	at cpw.mods.securejarhandler/cpw.mods.cl.ModuleClassLoader.lambda$findClass$15(ModuleClassLoader.java:219)
	at cpw.mods.securejarhandler/cpw.mods.cl.ModuleClassLoader.loadFromModule(ModuleClassLoader.java:229)
	at cpw.mods.securejarhandler/cpw.mods.cl.ModuleClassLoader.findClass(ModuleClassLoader.java:219)
	at cpw.mods.securejarhandler/cpw.mods.cl.ModuleClassLoader.loadClass(ModuleClassLoader.java:135)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	at TRANSFORMER/forge@47.3.0/net.minecraftforge.registries.GameData.init(GameData.java:107)
	at TRANSFORMER/forge@47.3.0/net.minecraftforge.registries.GameData.<clinit>(GameData.java:93)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.core.registries.BuiltInRegistries.forge(BuiltInRegistries.java:429)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.core.registries.BuiltInRegistries.forge(BuiltInRegistries.java:409)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.core.registries.BuiltInRegistries.<clinit>(BuiltInRegistries.java:121)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.server.Bootstrap.m_135870_(Bootstrap.java:43)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.client.main.Main.lambda$main$0(Main.java:151)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.spongepowered.asm.mixin.injection.throwables.InjectionError: Critical injection failure: Variable modifier method spectrum$binglebongle(ZLnet/minecraft/world/entity/Entity;)Z in spectrum.mixins.json:PlayerEntityMixin from mod spectrum failed injection check, 3 succeeded of 1 allowed.
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.injection.struct.InjectionInfo.postInject(InjectionInfo.java:473)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinTargetContext.applyInjections(MixinTargetContext.java:1384)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyInjections(MixinApplicatorStandard.java:1062)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyMixin(MixinApplicatorStandard.java:402)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.apply(MixinApplicatorStandard.java:327)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.TargetClassContext.apply(TargetClassContext.java:421)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.TargetClassContext.applyMixins(TargetClassContext.java:403)
	at MC-BOOTSTRAP/org.spongepowered.mixin/org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:363)
	... 25 more
Exiting with ERROR
[14:00:44] [WARN] [FabricLoader/Resolution]: Warnings were found!
 - §Emod 'Cardinal Components API (world saves)' (cardinal_components_level)§r 5.2.2 recommends any version of §6cardinal-components-world§r, which is missing!
	 - You should install any version of §6cardinal-components-world§r for the optimal experience.
Process exited with code 2.
Clipboard copy at: 25 Oct 2024 14:01:05 +0200
```

The interesting line is
```
Caused by: org.spongepowered.asm.mixin.injection.throwables.InjectionError: Critical injection failure: Variable modifier method spectrum$binglebongle(ZLnet/minecraft/world/entity/Entity;)Z in spectrum.mixins.json:PlayerEntityMixin from mod spectrum failed injection check, 3 succeeded of 1 allowed.
```

In the forge minecraft the attack method assignes to the critical hit flag 3 times. Since `STORE:LAST` isn't a valid ordinal selector it finds all 3 stores and then fails.