### PR TITLE
Decay away makes blackslag in the DD instead of Dirt

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/decay/DecayAwayBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/decay/DecayAwayBlock.java
@@ -107,6 +107,8 @@ public class DecayAwayBlock extends Block {
 					return Blocks.NETHERRACK.getDefaultState();
 				} else if (DimensionTypes.THE_END_ID.equals(identifier)) {
 					return Blocks.END_STONE.getDefaultState();
+				} else if (SpectrumDimensions.DIMENSION_ID.equals(identifier)) {
+					return Blocks.END_STONE.getDefaultState();
 				}
 				return Blocks.DIRT.getDefaultState();
 			}


### PR DESCRIPTION
Fixes the lag problem of the dirt decay away makes getting turned back into black materia by the midnight solution, and then reconverted by the decay away, in an endless cycle