### PR TITLE
Resonance drops don't stop searching for entries after finding one

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/data_loaders/ResonanceDropsDataLoader.java
+++ b/src/main/java/de/dafuqs/spectrum/data_loaders/ResonanceDropsDataLoader.java
@@ -53,9 +53,7 @@ public class ResonanceDropsDataLoader extends JsonDataLoader implements Identifi
 	
 	public static void applyResonance(BlockState minedState, BlockEntity blockEntity, List<ItemStack> droppedStacks) {
 		for (ResonanceDropProcessor entry : RESONANCE_DROPS) {
-			if (entry.process(minedState, blockEntity, droppedStacks)) {
-				return;
-			}
+		entry.process(minedState, blockEntity, droppedStacks);
 		}
 	}
 	


### PR DESCRIPTION
Fixes issue where having create compat enabled meant the pure zinc drop overrode all the other pure resource drops