### PR TITLE
Actually fix Dragonrending Pickaxe's Razing Level

### DIFF
--- a/src/main/resources/data/spectrum/recipes/pedestal/tier4/dragonrending_pickaxe.json
+++ b/src/main/resources/data/spectrum/recipes/pedestal/tier4/dragonrending_pickaxe.json
@@ -30,7 +30,7 @@
       "Enchantments": [
         {
           "id": "spectrum:razing",
-          "lvl": "1s"
+          "lvl": "3s"
         }
       ]
     },


### PR DESCRIPTION
Despite being set to have a default enchantment of Razing III instead of Razing I, the recipe was not also corrected