### PR TITLE
Add more furnace fuels

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/registries/SpectrumItems.java
+++ b/src/main/java/de/dafuqs/spectrum/registries/SpectrumItems.java
@@ -995,15 +995,14 @@ public class SpectrumItems {
 
 		FuelRegistry.INSTANCE.add(SpectrumItems.PURE_COAL, 3200);
 		FuelRegistry.INSTANCE.add(SpectrumBlocks.PURE_COAL_BLOCK, 32000);
-
+		
 		FuelRegistry.INSTANCE.add(SpectrumItems.VEGETAL, 800);
 		FuelRegistry.INSTANCE.add(SpectrumBlocks.VEGETAL_BLOCK, 8000);
-
-		FuelRegistry.INSTANCE.add(SpectrumItems.PURE_ALCOHOL,50000);
-		FuelRegistry.INSTANCE.add(SpectrumItems.CHRYSOCOLLA,50000);
+		
+		FuelRegistry.INSTANCE.add(SpectrumItems.PURE_ALCOHOL, 16000);
+		FuelRegistry.INSTANCE.add(SpectrumItems.CHRYSOCOLLA, 16000);
 
 		FuelRegistry.INSTANCE.add(SpectrumItems.INCANDESCENT_ESSENCE, 2400);
-		FuelRegistry.INSTANCE.add(SpectrumItems.ORANGE_PIGMENT, 2400);
 
 		FuelRegistry.INSTANCE.add(SpectrumItemTags.COLORED_FENCES, 300);
 		FuelRegistry.INSTANCE.add(SpectrumItemTags.COLORED_FENCE_GATES, 300);

--- a/src/main/java/de/dafuqs/spectrum/registries/SpectrumItems.java
+++ b/src/main/java/de/dafuqs/spectrum/registries/SpectrumItems.java
@@ -996,6 +996,15 @@ public class SpectrumItems {
 		FuelRegistry.INSTANCE.add(SpectrumItems.PURE_COAL, 3200);
 		FuelRegistry.INSTANCE.add(SpectrumBlocks.PURE_COAL_BLOCK, 32000);
 
+		FuelRegistry.INSTANCE.add(SpectrumItems.VEGETAL, 800);
+		FuelRegistry.INSTANCE.add(SpectrumBlocks.VEGETAL_BLOCK, 8000);
+
+		FuelRegistry.INSTANCE.add(SpectrumItems.PURE_ALCOHOL,50000);
+		FuelRegistry.INSTANCE.add(SpectrumItems.CHRYSOCOLLA,50000);
+
+		FuelRegistry.INSTANCE.add(SpectrumItems.INCANDESCENT_ESSENCE, 2400);
+		FuelRegistry.INSTANCE.add(SpectrumItems.ORANGE_PIGMENT, 2400);
+
 		FuelRegistry.INSTANCE.add(SpectrumItemTags.COLORED_FENCES, 300);
 		FuelRegistry.INSTANCE.add(SpectrumItemTags.COLORED_FENCE_GATES, 300);
 	}


### PR DESCRIPTION
Added fuel times:
Vegetal: Smelts 4 items
Vegetal Block: Smelts 40 items (gives a slight bonus, like coal blocks)

Pure Alcohol/Chrysocolla: Smelts 250 Items. Don't try this at home

Orange Pigment Specifically (as it represents heat): Smelts 12 items

Incandescent Essence: Smelts 12 items, dubious on whether we should add this, as azzy makes a decent argument for not having this usable as fuel

Side note: due to being in the #non_flammable_woods tag, Weeping Gala wood can not be used as a furnace fuel. We should really come to a consensus on whether weeping gala should be flammable or not, as this is currently quite inconsistent in the code base