### PR TITLE
Allow eternal slumber fillables

### DIFF
--- a/src/main/resources/data/spectrum/recipes/potion_workshop_brewing/eternal_slumber.json
+++ b/src/main/resources/data/spectrum/recipes/potion_workshop_brewing/eternal_slumber.json
@@ -15,7 +15,7 @@
   "potency_modifier": 0.1,
   "applicable_to_potions": true,
   "applicable_to_tipped_arrows": false,
-  "applicable_to_potion_fillables": false,
+  "applicable_to_potion_fillables": true,
   "required_advancement": "spectrum:unlocks/potions/strong_sleep_effects",
   "ink_color": "spectrum:purple",
   "ink_cost": 32,


### PR DESCRIPTION
Making potion fillables was disabled for Eternal Slumber to prevent Nightfall's Blade cheese, but the Nightfall's Blade already has code to make strong sleep effects (eternal and fatal slumber) cost way more. As such, I think it's fine to enable fillable for Eternal Slumber. Also, this means you can now use it on Concealing Oils.