### PR TITLE
Bandaid fix for ink unlocking issue

### DIFF
--- a/src/main/resources/data/spectrum/advancements/milestones/unlock_ink_use.json
+++ b/src/main/resources/data/spectrum/advancements/milestones/unlock_ink_use.json
@@ -5,6 +5,24 @@
       "conditions": {
         "advancement_identifier": "spectrum:midgame/spectrum_midgame"
       }
+    },
+    "has_flask": {
+  	  "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "spectrum:ink_flask"
+            ]
+          }
+        ]
+      }
     }
-  }
+  },
+  "requirements": [
+    [
+      "reached_midgame",
+      "has_flask"
+    ]
+  ]
 }


### PR DESCRIPTION
Fixes #557 by making `spectrum:milestones/unlock_ink_use` also trigger from having an Ink Flask in your inventory. 

The flask recipe unlocks from the existing advancement `spectrum:unlocks/items/basic_ink_storage_items` rather than the new `spectrum:milestones/unlock_ink_use`, so players should have access to flasks even while lacking `spectrum:milestones/unlock_ink_use` due to the bug.

This does not fix the larger issue behind this bug - namely, that newly added advancements using the `revelationary:advancement_gotten` trigger will be unobtainable in worlds where the triggering advancement has already been obtained.