### PR TITLE
Fix kindling advancements

### DIFF
--- a/src/main/resources/data/spectrum/advancements/hidden/entity_interact/kindling.json
+++ b/src/main/resources/data/spectrum/advancements/hidden/entity_interact/kindling.json
@@ -1,0 +1,50 @@
+{
+    "criteria": {
+      "entity_interact": {
+        "trigger": "minecraft:player_interacted_with_entity",
+        "conditions": {
+          "player": [
+            {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type": "spectrum:kindling"
+              }
+            }
+          ]
+        }
+      },
+      "entity_hurt_player": {
+        "trigger": "minecraft:entity_hurt_player",
+        "conditions": {
+          "damage": {
+            "source_entity": {
+              "type": "spectrum:kindling"
+            }
+          }
+        }
+      },
+      "player_hurt_entity": {
+        "trigger": "minecraft:player_hurt_entity",
+        "conditions": {
+          "entity": [
+            {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type": "spectrum:kindling"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "requirements": [
+      [
+        "entity_interact",
+        "entity_hurt_player",
+        "player_hurt_entity"
+      ]
+    ]
+  }
+  

--- a/src/main/resources/data/spectrum/advancements/pluck_effulgent_feather.json
+++ b/src/main/resources/data/spectrum/advancements/pluck_effulgent_feather.json
@@ -4,6 +4,7 @@
     "icon": {
       "item": "spectrum:effulgent_feather"
     },
+    "hidden": true,
     "title": {
       "translate": "advancements.spectrum.pluck_effulgent_feather.title"
     },

--- a/src/main/resources/data/spectrum/advancements/remember_kindling.json
+++ b/src/main/resources/data/spectrum/advancements/remember_kindling.json
@@ -21,11 +21,26 @@
         }
       }
     },
+    "interacted_with_kindling": {
+      "trigger": "revelationary:advancement_gotten",
+      "conditions": {
+        "advancement_identifier": "spectrum:hidden/entity_interact/kindling"
+      }
+    },
     "gotten_previous": {
       "trigger": "revelationary:advancement_gotten",
       "conditions": {
-        "advancement_identifier": "spectrum:break_cracked_dragonbone"
+        "advancement_identifier": "spectrum:unlocks/blocks/kindling_memory"
       }
     }
-  }
+  },
+  "requirements": [
+    [
+      "remembered_kindling",
+      "interacted_with_kindling"
+    ],
+    [
+      "gotten_previous"
+    ]
+  ]
 }


### PR DESCRIPTION
Now that we have the ability to turn memories into heads, it's possible to bypass the "hatch a kindling from a memory" check by turning your memory into a head and then a spawner, which prevents you from unlocking feathers or bloodstone until you hatch a kindling the "proper" way. This fixes that issue by allowing `spectrum:remember_kindling` to trigger when you interact with a kindling in-world, so long as you've already unlocked the memory recipe. It also makes `spectrum:pluck_effulgent_feather` hidden until you unlock it, both to prevent spoiling the **RUN** and to prevent it from appearing in the advancement tree with a shrouded item for an icon.

The change to `spectrum:remember_kindling` does mean that it will trigger immediately upon unlocking the memory recipe if you've already interacted with a kindling somehow (ie someone else's kindling on a multiplayer server), but I think that's an OK price to pay in exchange for fixing the spawner bypass.