### PR TITLE
Blacklist colored preservation stone from paintbrush recoloring

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/helpers/BlockVariantHelper.java
+++ b/src/main/java/de/dafuqs/spectrum/helpers/BlockVariantHelper.java
@@ -25,7 +25,7 @@ public class BlockVariantHelper {
 		
 		BlockState blockState = world.getBlockState(blockPos);
 		
-		if (blockState.isIn(SpectrumBlockTags.INK_EFFECT_BLACKLISTED)) {
+		if (blockState.isIn(SpectrumBlockTags.INK_EFFECT_BLACKLISTED) || blockState.getHardness(world,blockPos) == -1) {
 			return Blocks.AIR.getDefaultState();
 		}
 		

--- a/src/main/resources/data/spectrum/tags/blocks/colored_preservation_stone.json
+++ b/src/main/resources/data/spectrum/tags/blocks/colored_preservation_stone.json
@@ -1,0 +1,20 @@
+{
+  "values": [
+    "spectrum:black_chiseled_preservation_stone",
+    "spectrum:blue_chiseled_preservation_stone",
+    "spectrum:brown_chiseled_preservation_stone",
+    "spectrum:cyan_chiseled_preservation_stone",
+    "spectrum:gray_chiseled_preservation_stone",
+    "spectrum:green_chiseled_preservation_stone",
+    "spectrum:light_blue_chiseled_preservation_stone",
+    "spectrum:light_gray_chiseled_preservation_stone",
+    "spectrum:lime_chiseled_preservation_stone",
+    "spectrum:magenta_chiseled_preservation_stone",
+    "spectrum:orange_chiseled_preservation_stone",
+    "spectrum:pink_chiseled_preservation_stone",
+    "spectrum:purple_chiseled_preservation_stone",
+    "spectrum:red_chiseled_preservation_stone",
+    "spectrum:white_chiseled_preservation_stone",
+    "spectrum:yellow_chiseled_preservation_stone"
+  ]
+}

--- a/src/main/resources/data/spectrum/tags/blocks/ink_effect_blacklisted.json
+++ b/src/main/resources/data/spectrum/tags/blocks/ink_effect_blacklisted.json
@@ -1,5 +1,5 @@
 {
   "values": [
-
+    "#spectrum:colored_preservation_stone"
   ]
 }

--- a/src/main/resources/data/spectrum/tags/blocks/ink_effect_blacklisted.json
+++ b/src/main/resources/data/spectrum/tags/blocks/ink_effect_blacklisted.json
@@ -1,5 +1,5 @@
 {
   "values": [
-    "#spectrum:colored_preservation_stone"
+    
   ]
 }


### PR DESCRIPTION
Currently, colored preservation stone gets caught by the `getCursedBlockColorVariant` system, and thus it's a valid target to be recolored using a paintbrush. Given that preservation stone is an unbreakable structure component, I don't think it makes much sense for players to be able to just recolor it at will - particularly since it allows you to (intentionally or otherwise) change the color of the "backup" preservation stone above the roundels in mixing ruins. 

~~This PR adds colored preservation stone to the ink_effect_blacklisted tag so it can no longer be recolored.~~
This PR adds a hardness check to getCursedBlockVariant so that it always fails on unbreakable blocks.