### PR TITLE
Add malachite smelting recipes

### DIFF
--- a/src/main/resources/data/spectrum/recipes/blasting/ore/malachite_ores.json
+++ b/src/main/resources/data/spectrum/recipes/blasting/ore/malachite_ores.json
@@ -1,0 +1,9 @@
+{
+	"type": "minecraft:blasting",
+	"ingredient": {
+		"tag": "spectrum:malachite_ores"
+	},
+	"result": "spectrum:raw_malachite",
+	"experience": 2,
+	"cookingtime": 100
+}

--- a/src/main/resources/data/spectrum/recipes/mod_integration/tech_reborn/industrial_grinder/malachite_from_ore.json
+++ b/src/main/resources/data/spectrum/recipes/mod_integration/tech_reborn/industrial_grinder/malachite_from_ore.json
@@ -1,0 +1,28 @@
+{
+	"type": "techreborn:industrial_grinder",
+	"power": 64,
+	"time": 100,
+	"tank": {
+		"fluid": "spectrum:liquid_crystal",
+		"amount": 100
+	},
+	"ingredients": [
+		{
+			"tag": "spectrum:malachite_ores"
+		}
+	],
+	"results": [
+		{
+			"item": "spectrum:raw_malachite",
+			"count": 4
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"techreborn"
+			]
+		}
+	]
+}

--- a/src/main/resources/data/spectrum/recipes/smelting/ore/malachite_ores.json
+++ b/src/main/resources/data/spectrum/recipes/smelting/ore/malachite_ores.json
@@ -1,0 +1,9 @@
+{
+	"type": "minecraft:smelting",
+	"ingredient": {
+		"tag": "spectrum:malachite_ores"
+	},
+	"result": "spectrum:raw_malachite",
+	"experience": 2,
+	"cookingtime": 200
+}


### PR DESCRIPTION
Malachite ore... can't be processed at all. This very much sucks if your only tool you have of a high enough mining level has silk touch (example, the bedrock pickaxe which comes with silk).

This PR fixes that, adding the missing smelting recipes for the ore