### PR TITLE
Buff Kimchi

### DIFF
--- a/src/main/resources/assets/spectrum/lang/en_us.json
+++ b/src/main/resources/assets/spectrum/lang/en_us.json
@@ -3890,7 +3890,7 @@
   "book.spectrum.guidebook.titration_barrel.le_fishe_au_chocolat.text": "*It's certainly something.*",
   "book.spectrum.guidebook.titration_barrel.page0.text": "The idea of fermenting [food](entry://cuisine/titration_barrel@kimchi) and [drinks](entry://cuisine/infused_beverages) in [Colored Wood](entry://general/colored_trees@colored_wood) was not far to seek.\\\nOver time, the properties of the wood affect the contents. The results are sometimes more delicious, sometimes less delicious (though the latter could be due to my cooking skills), but always interesting.\\\n\\\nThe barrel holds up to a stack of items and one bucket of liquid.",
   "book.spectrum.guidebook.titration_barrel.page1.text": "*Sometimes it feels like that when I blink the world has ceased to exist? Each time the barrel fermentation process seems to have progressed.*",
-  "book.spectrum.guidebook.titration_barrel.page2.text": "Fermentation is not just for drinks! Made from 3 different vegetables, Kimchi is a hearty dish, best served as a side.",
+  "book.spectrum.guidebook.titration_barrel.page2.text": "Fermentation is not just for drinks! Made from 2 different vegetables, Kimchi is a hearty dish, best served as a side.",
   "book.spectrum.guidebook.titration_barrel.page3.text": "Takes a little time, but more efficient than just throwing the ingredients together.",
   "book.spectrum.guidebook.titration_barrel.page4.text": "Slightly fermented, it still retains the properties of [Milk](item://minecraft:milk_bucket). Eating it will remove any status effects currently active.",
   "book.spectrum.guidebook.titration_barrel.page5.text": "A great snack. Biting off a piece is quick and even makes me feel reasonably full.\\\nPleasantly sweet and fruity.",

--- a/src/main/resources/data/spectrum/recipes/titration_barrel/kimchi.json
+++ b/src/main/resources/data/spectrum/recipes/titration_barrel/kimchi.json
@@ -8,10 +8,6 @@
     {
       "tag": "c:vegetables",
       "count": 4
-    },
-    {
-      "tag": "c:vegetables",
-      "count": 4
     }
   ],
   "fluid": {
@@ -20,6 +16,6 @@
   "min_fermentation_time_hours": 4,
   "result": {
     "item": "spectrum:kimchi",
-    "count": 8
+    "count": 16
   }
 }


### PR DESCRIPTION
Changes kimchi recipe to have doubled yield, and only need two veggies instead of three (so you don't need to awkwardly double up on carrots/golden carrots)