### PR TITLE
Fix mirrored gem blocks in gen 1 textures

### DIFF
--- a/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/citrine_block.json
+++ b/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/citrine_block.json
@@ -1,0 +1,7 @@
+{
+	"variants": {
+		"": {
+			"model": "spectrum:block/citrine_block"
+		}
+	}
+}

--- a/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/moonstone_block.json
+++ b/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/moonstone_block.json
@@ -1,0 +1,7 @@
+{
+	"variants": {
+		"": {
+			"model": "spectrum:block/moonstone_block"
+		}
+	}
+}

--- a/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/moonstone_chiseled_basalt.json
+++ b/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/moonstone_chiseled_basalt.json
@@ -1,0 +1,29 @@
+{
+	"variants": {
+		"facing=down": {
+			"model": "spectrum:block/moonstone_chiseled_basalt_down"
+		},
+		"facing=east": {
+			"model": "spectrum:block/moonstone_chiseled_basalt",
+			"x": 90,
+			"y": 90
+		},
+		"facing=north": {
+			"model": "spectrum:block/moonstone_chiseled_basalt",
+			"x": 90
+		},
+		"facing=south": {
+			"model": "spectrum:block/moonstone_chiseled_basalt",
+			"x": 90,
+			"y": 180
+		},
+		"facing=up": {
+          "model": "spectrum:block/moonstone_chiseled_basalt_up"
+		},
+		"facing=west": {
+			"model": "spectrum:block/moonstone_chiseled_basalt",
+			"x": 90,
+			"y": 270
+		}
+	}
+}

--- a/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/moonstone_chiseled_calcite.json
+++ b/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/moonstone_chiseled_calcite.json
@@ -1,0 +1,29 @@
+{
+	"variants": {
+		"facing=down": {
+			"model": "spectrum:block/moonstone_chiseled_calcite_down"
+		},
+		"facing=east": {
+			"model": "spectrum:block/moonstone_chiseled_calcite",
+			"x": 90,
+			"y": 90
+		},
+		"facing=north": {
+			"model": "spectrum:block/moonstone_chiseled_calcite",
+			"x": 90
+		},
+		"facing=south": {
+			"model": "spectrum:block/moonstone_chiseled_calcite",
+			"x": 90,
+			"y": 180
+		},
+		"facing=up": {
+          "model": "spectrum:block/moonstone_chiseled_calcite_up"
+		},
+		"facing=west": {
+			"model": "spectrum:block/moonstone_chiseled_calcite",
+			"x": 90,
+			"y": 270
+		}
+	}
+}

--- a/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/onyx_block.json
+++ b/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/onyx_block.json
@@ -1,0 +1,7 @@
+{
+	"variants": {
+		"": {
+			"model": "spectrum:block/onyx_block"
+		}
+	}
+}

--- a/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/topaz_block.json
+++ b/src/main/resources/resourcepacks/spectrum_generation_1/assets/spectrum/blockstates/topaz_block.json
@@ -1,0 +1,7 @@
+{
+	"variants": {
+		"": {
+			"model": "spectrum:block/topaz_block"
+		}
+	}
+}


### PR DESCRIPTION
Fixes the below problem, which is caused by the gen 1 resource pack failing to override the new mirrored block models for raw gem blocks.

![image](https://github.com/user-attachments/assets/dbf1617b-2333-47fc-872b-2d99f5261e59)
