### PR TITLE
Bedrock Anvil Item Coloring

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/BedrockAnvilBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/BedrockAnvilBlock.java
@@ -39,6 +39,7 @@ public class BedrockAnvilBlock extends AnvilBlock {
 		super.appendTooltip(stack, world, tooltip, options);
 		tooltip.add(Text.translatable("container.spectrum.bedrock_anvil.tooltip").formatted(Formatting.GRAY));
 		tooltip.add(Text.translatable("container.spectrum.bedrock_anvil.tooltip2").formatted(Formatting.GRAY));
+		tooltip.add(Text.translatable("container.spectrum.bedrock_anvil.tooltip3").formatted(Formatting.GRAY));
 	}
 	
 }

--- a/src/main/java/de/dafuqs/spectrum/inventories/BedrockAnvilScreen.java
+++ b/src/main/java/de/dafuqs/spectrum/inventories/BedrockAnvilScreen.java
@@ -2,6 +2,7 @@ package de.dafuqs.spectrum.inventories;
 
 import de.dafuqs.spectrum.*;
 import de.dafuqs.spectrum.helpers.*;
+import de.dafuqs.spectrum.items.*;
 import de.dafuqs.spectrum.networking.*;
 import net.fabricmc.api.*;
 import net.fabricmc.fabric.api.client.networking.v1.*;
@@ -187,6 +188,24 @@ public class BedrockAnvilScreen extends ForgingScreen<BedrockAnvilScreenHandler>
 	public void onSlotUpdate(ScreenHandler handler, int slotId, ItemStack stack) {
 		if (slotId == 0) {
 			this.nameField.setText(stack.isEmpty() ? "" : stack.getName().getString());
+			if(!(this.handler.getSlot(1).getStack().getItem() instanceof PigmentItem))
+			{
+				if(stack.getName() instanceof MutableText mutableText)
+				{
+					if(mutableText.getStyle().getColor() == null)
+					{
+						this.nameField.setEditableColor(-1);
+					}
+					else
+					{
+						this.nameField.setEditableColor(mutableText.getStyle().getColor().getRgb());
+					}
+				}
+				else{
+					this.nameField.setEditableColor(-1);
+				}
+			}
+			
 			this.nameField.setEditable(!stack.isEmpty());
 			
 			String loreString = LoreHelper.getStringFromLoreTextArray(LoreHelper.getLoreList(stack));
@@ -195,6 +214,29 @@ public class BedrockAnvilScreen extends ForgingScreen<BedrockAnvilScreenHandler>
 			
 			this.setFocused(this.nameField);
 		}
+		if (slotId == 1)
+		{
+			if(stack.getItem() instanceof PigmentItem)
+			{
+				this.nameField.setEditableColor(ColorHelper.getInt(((PigmentItem)stack.getItem()).getColor()));
+			}
+			else
+			{
+				if(this.handler.getSlot(0).getStack().getName() instanceof MutableText mutableText)
+				{
+					if(mutableText.getStyle().getColor() == null)
+					{
+						this.nameField.setEditableColor(-1);
+					}
+					else
+					{
+						this.nameField.setEditableColor(mutableText.getStyle().getColor().getRgb());
+					}
+				}
+				else{
+					this.nameField.setEditableColor(-1);
+				}
+			}
+		}
 	}
-	
 }

--- a/src/main/resources/assets/spectrum/lang/en_us.json
+++ b/src/main/resources/assets/spectrum/lang/en_us.json
@@ -2190,7 +2190,7 @@
   "book.spectrum.guidebook.base_trinkets.name": "Base Trinkets",
   "book.spectrum.guidebook.base_trinkets.page0.text": "These basic accessories will serve me well as a starting point for more advanced Trinkets.\\\nAll final Trinkets are created in the [Fusion Shrine](entry://general/fusion_shrine).",
   "book.spectrum.guidebook.bedrock_anvil.page0.text": "I've used my Anvil plenty (a lot of Anvils, actually). [Item Crushing](entry://general/item_crushing), repairing and enchanting are burning a hole in my iron supply.\\\nTo make the Anvil last longer - indestructible, in fact - Bedrock seems like the perfect choice.\\\n\\\nIt allows me to rename items for free and has no maximum repair limit.",
-  "book.spectrum.guidebook.bedrock_anvil.page1.text": "It also allows me to add descriptions to my items.\\\n\\\n*Pro tip: \"\\n\" will split the text into multiple lines.*",
+  "book.spectrum.guidebook.bedrock_anvil.page1.text": "It also allows me to add descriptions to my items, as well as a spark of color with some pigment.\\\n\\\n*Pro tip: \"\\n\" will split the text into multiple lines.*\\\n*Also, leaving the name field blank will reset the name.*",
   "book.spectrum.guidebook.bedrock_armor.page0.text": "The strongest material I could find so far was Netherite. However, repairing [#](bb00bb)Netherite Armor[#]() was more expensive than making the armor itself. Also, the protection decreased with each scratch. All this is less of a problem if the armor simply *cannot* be damaged in the first place.\\\n\\\n*Never wilt, stone blossom.*",
   "book.spectrum.guidebook.bedrock_armor.page1.text": "The Bedrock Helmet comes with **Projectile Protection V**.",
   "book.spectrum.guidebook.bedrock_armor.page2.text": "The Bedrock Chestplate comes with **Protection V**.",
@@ -4013,11 +4013,12 @@
   "commands.spectrum.progression_sanity.success": "Printed the sanity checks findings to the servers console",
   "commands.spectrum.spawn_shooting_star.success": "Spawned %d shooting stars for each player",
 
-  "container.spectrum.bedrock_anvil": "Repair & write Lore",
+  "container.spectrum.bedrock_anvil": "Repair & Customize",
   "container.spectrum.bedrock_anvil.lore": "Lore:",
   "container.spectrum.bedrock_anvil.tooltip": "Indestructible. Free renaming, unlimited",
   "container.spectrum.bedrock_anvil.tooltip2": "repair cap & able to add Lore to Items",
-  "container.spectrum.modonomicon.crystallarieum.catalyst": "Catalyst:\nAccel:\nInk Cons:\nUsed Up:",
+	"container.spectrum.bedrock_anvil.tooltip3": "Add pigment to items to color their name",
+	"container.spectrum.modonomicon.crystallarieum.catalyst": "Catalyst:\nAccel:\nInk Cons:\nUsed Up:",
 
   "container.spectrum.rei.anvil_crushing.high_force_required": "High force required",
   "container.spectrum.rei.anvil_crushing.low_force_required": "Low force required",


### PR DESCRIPTION
Combine items with pigment in the bedrock anvil to color their names.

Minor concern i've noticed is that the act of resetting an item's name, while being consistent with vanilla, is a bit unintuitive.
I made a note of it in the guidebook, but I worry that it might not be enough. 