### PR TITLE
Improve special-case amalgam explosions

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/boom/IncandescentAmalgamItem.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/boom/IncandescentAmalgamItem.java
@@ -31,8 +31,7 @@ public class IncandescentAmalgamItem extends BlockItem implements DamageAwareIte
 		user.damage(SpectrumDamageTypes.incandescence(world), 500.0F);
 		
 		float explosionPower = getExplosionPower(stack, false);
-		world.createExplosion(user, SpectrumDamageTypes.incandescence(world), new EntityExplosionBehavior(user), user.getX(), user.getY(), user.getZ(), explosionPower / 5, false, World.ExplosionSourceType.BLOCK);
-		world.createExplosion(user, SpectrumDamageTypes.incandescence(world), new EntityExplosionBehavior(user), user.getX(), user.getY(), user.getZ(), explosionPower, true, World.ExplosionSourceType.NONE);
+		world.createExplosion(user, SpectrumDamageTypes.incandescence(world), new EntityExplosionBehavior(user), user.getX(), user.getY(), user.getZ(), explosionPower, true, World.ExplosionSourceType.BLOCK);
 		
 		if (user.isAlive() && user instanceof ServerPlayerEntity serverPlayerEntity && !serverPlayerEntity.isCreative()) {
 			Support.grantAdvancementCriterion(serverPlayerEntity, "survive_drinking_incandescent_amalgam", "survived_drinking_incandescent_amalgam");

--- a/src/main/java/de/dafuqs/spectrum/blocks/boom/IncandescentAmalgamItem.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/boom/IncandescentAmalgamItem.java
@@ -58,8 +58,7 @@ public class IncandescentAmalgamItem extends BlockItem implements DamageAwareIte
 		
 		float explosionPower = getExplosionPower(stack, true);
 		var world = itemEntity.getWorld();
-		world.createExplosion(itemEntity, SpectrumDamageTypes.incandescence(world, itemEntity), new EntityExplosionBehavior(itemEntity), itemEntity.getX(), itemEntity.getY(), itemEntity.getZ(), explosionPower / 8F, false, World.ExplosionSourceType.BLOCK);
-		world.createExplosion(itemEntity, SpectrumDamageTypes.incandescence(world, itemEntity), new EntityExplosionBehavior(itemEntity), itemEntity.getX(), itemEntity.getY(), itemEntity.getZ(), explosionPower, true, World.ExplosionSourceType.NONE);
+		world.createExplosion(itemEntity, SpectrumDamageTypes.incandescence(world, itemEntity), new EntityExplosionBehavior(itemEntity), itemEntity.getX(), itemEntity.getY(), itemEntity.getZ(), explosionPower, true, World.ExplosionSourceType.BLOCK);
 	}
 
 	@Override
@@ -72,7 +71,7 @@ public class IncandescentAmalgamItem extends BlockItem implements DamageAwareIte
 		if (alcPercent <= 0) {
 			return 6;
 		} else {
-			return alcPercent + (useCount ? stack.getCount() / 8F : 0);
+			return alcPercent * (useCount ? 0.875F + (stack.getCount() / 8F) : 1);
 		}
 	}
 	

--- a/src/main/java/de/dafuqs/spectrum/blocks/boom/IncandescentAmalgamItem.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/boom/IncandescentAmalgamItem.java
@@ -31,7 +31,7 @@ public class IncandescentAmalgamItem extends BlockItem implements DamageAwareIte
 		user.damage(SpectrumDamageTypes.incandescence(world), 500.0F);
 		
 		float explosionPower = getExplosionPower(stack, false);
-		world.createExplosion(user, SpectrumDamageTypes.incandescence(world), new EntityExplosionBehavior(user), user.getX(), user.getY(), user.getZ(), explosionPower, true, World.ExplosionSourceType.BLOCK);
+		world.createExplosion(user, SpectrumDamageTypes.incandescence(world), new EntityExplosionBehavior(user), user.getX(), user.getEyeY(), user.getZ(), explosionPower, true, World.ExplosionSourceType.BLOCK);
 		
 		if (user.isAlive() && user instanceof ServerPlayerEntity serverPlayerEntity && !serverPlayerEntity.isCreative()) {
 			Support.grantAdvancementCriterion(serverPlayerEntity, "survive_drinking_incandescent_amalgam", "survived_drinking_incandescent_amalgam");


### PR DESCRIPTION
- Eating amalgam no longer reduces the block damage of the resulting explosion
  - This was not documented anywhere, and led to some players being confused why their amalgam wasn't able to crack dragonbone
- Explosion when eating amalgam is now centered on your head rather than at your feet
  - This both makes logical sense (why would eating an explosive make your feet explode) and makes it a bit easier to actually hit things with the explosion
- Reworked explosion power formula for damaging an in-world stack of amalgam
  - Explosion power from a damaged stack is now `base power * [ 0.875 + (stack size / 8) ]`
  - A stack of 1 item will explode identically to the placed or eaten version
  - Each additional item in the stack will add 0.125 to the explosion power multiplier
  - A stack of 2 items will explode with 1.125x power, 3 items will explode with 1.25x power, etc