### PR TITLE
Make survive_fatal_slumber trigger from surviving in any way

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/mixin/LivingEntityMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/LivingEntityMixin.java
@@ -493,15 +493,16 @@ public abstract class LivingEntityMixin {
 
 			var damage = Float.MAX_VALUE;
 			if (SleepStatusEffect.isImmuneish(entity)) {
-				if (entity instanceof PlayerEntity player) {
+				if (entity instanceof PlayerEntity player)
 					damage = entity.getHealth() * 0.95F;
-					Support.grantAdvancementCriterion((ServerPlayerEntity) player, "lategame/survive_fatal_slumber", "get_slumbered_idiot");
-				}
-				else {
+				else
 					damage = entity.getMaxHealth() * 0.3F;
-				}
 			}
+
 			entity.damage(SpectrumDamageTypes.sleep(entity.getWorld(), null), damage);
+			if (entity.isAlive() && entity instanceof ServerPlayerEntity serverPlayerEntity && !serverPlayerEntity.isCreative()) {
+				Support.grantAdvancementCriterion(serverPlayerEntity, "lategame/survive_fatal_slumber", "survived_fatal_slumber");
+			}
 		}
 	}
 

--- a/src/main/resources/data/spectrum/advancements/lategame/survive_fatal_slumber.json
+++ b/src/main/resources/data/spectrum/advancements/lategame/survive_fatal_slumber.json
@@ -14,7 +14,7 @@
     "hidden": true
   },
   "criteria": {
-    "get_slumbered_idiot": {
+    "survived_fatal_slumber": {
       "trigger": "minecraft:impossible"
     },
     "gotten_previous": {


### PR DESCRIPTION
Currently, the trigger for the "survive fatal slumber" advancement is only activated if you survive by passing the isImmuneish() check that reduces the damage from Float.MAX_VALUE to 95% of your max health. This changes it so the advancement triggers if you survive the kill shot in any way.

Note that "in any way" does not include using a Totem of Undying, since for some reason Fatal Slumber damage is set to bypass that.