### PR TITLE
Automatically migrate pre-InkColor registry InkStorages

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/api/energy/InkStorage.java
+++ b/src/main/java/de/dafuqs/spectrum/api/energy/InkStorage.java
@@ -1,7 +1,6 @@
 package de.dafuqs.spectrum.api.energy;
 
 import de.dafuqs.spectrum.api.energy.color.*;
-import de.dafuqs.spectrum.registries.*;
 import net.minecraft.nbt.*;
 import net.minecraft.text.*;
 import net.minecraft.util.*;
@@ -165,9 +164,11 @@ public interface InkStorage extends Clearable {
 		Map<InkColor, Long> energy = new HashMap<>();
 		if (compound != null) {
 			for (String key : compound.getKeys()) {
-				InkColor inkColor = SpectrumRegistries.INK_COLORS.get(new Identifier(key));
-				long amount = compound.getLong(key);
-				energy.put(inkColor, amount);
+				Optional<InkColor> color = InkColor.ofIdString(key);
+				if (color.isPresent()) {
+					long amount = compound.getLong(key);
+					energy.put(color.get(), amount);
+				}
 			}
 		}
 		return energy;

--- a/src/main/java/de/dafuqs/spectrum/api/energy/color/InkColor.java
+++ b/src/main/java/de/dafuqs/spectrum/api/energy/color/InkColor.java
@@ -1,5 +1,6 @@
 package de.dafuqs.spectrum.api.energy.color;
 
+import de.dafuqs.spectrum.*;
 import de.dafuqs.spectrum.helpers.*;
 import de.dafuqs.spectrum.registries.*;
 import net.minecraft.registry.tag.*;
@@ -46,7 +47,12 @@ public class InkColor {
 	}
 	
 	public static Optional<InkColor> ofIdString(String idString) {
-		return SpectrumRegistries.INK_COLORS.getOrEmpty(new Identifier(idString));
+		try {
+			Identifier id = new Identifier(idString);
+			return SpectrumRegistries.INK_COLORS.getOrEmpty(id).or(() -> SpectrumRegistries.INK_COLORS.getOrEmpty(SpectrumCommon.locate(idString)));
+		} catch (InvalidIdentifierException ignored) {
+			return Optional.empty();
+		}
 	}
 	
 	public DyeColor getDyeColor() {

--- a/src/main/java/de/dafuqs/spectrum/api/energy/storage/IndividualCappedInkStorage.java
+++ b/src/main/java/de/dafuqs/spectrum/api/energy/storage/IndividualCappedInkStorage.java
@@ -130,7 +130,7 @@ public class IndividualCappedInkStorage implements InkStorage {
 	
 	public static IndividualCappedInkStorage fromNbt(@NotNull NbtCompound compound) {
 		long maxEnergyPerColor = compound.getLong("MaxEnergyPerColor");
-		Map<InkColor, Long> colors = InkStorage.readEnergy(compound.getCompound("Energy"));
+		Map<InkColor, Long> colors = InkStorage.readEnergy(compound.contains("Energy") ? compound.getCompound("Energy") : compound);
 		return new IndividualCappedInkStorage(maxEnergyPerColor, colors);
 	}
 	

--- a/src/main/java/de/dafuqs/spectrum/api/energy/storage/TotalCappedElementalMixingInkStorage.java
+++ b/src/main/java/de/dafuqs/spectrum/api/energy/storage/TotalCappedElementalMixingInkStorage.java
@@ -132,7 +132,7 @@ public class TotalCappedElementalMixingInkStorage extends TotalCappedInkStorage 
 	
 	public static TotalCappedElementalMixingInkStorage fromNbt(@NotNull NbtCompound compound) {
 		long maxEnergyTotal = compound.getLong("MaxEnergyTotal");
-		Map<InkColor, Long> energy = InkStorage.readEnergy(compound.getCompound("Energy"));
+		Map<InkColor, Long> energy = InkStorage.readEnergy(compound.contains("Energy") ? compound.getCompound("Energy") : compound);
 		return new TotalCappedElementalMixingInkStorage(maxEnergyTotal, energy);
 	}
 	

--- a/src/main/java/de/dafuqs/spectrum/api/energy/storage/TotalCappedInkStorage.java
+++ b/src/main/java/de/dafuqs/spectrum/api/energy/storage/TotalCappedInkStorage.java
@@ -116,7 +116,7 @@ public class TotalCappedInkStorage implements InkStorage {
 	
 	public static TotalCappedInkStorage fromNbt(@NotNull NbtCompound compound) {
 		long maxEnergyTotal = compound.getLong("MaxEnergyTotal");
-		Map<InkColor, Long> colors = InkStorage.readEnergy(compound.getCompound("Energy"));
+		Map<InkColor, Long> colors = InkStorage.readEnergy(compound.contains("Energy") ? compound.getCompound("Energy") : compound);
 		return new TotalCappedInkStorage(maxEnergyTotal, colors);
 	}
 	


### PR DESCRIPTION
These changes allow `InkStorage` instances created prior to Spectrum v1.8 to migrate to the new Registry-based `InkColor` system automatically.

BlockEntities and ItemStacks load as expected; the player doesn't have to do anything special.

BlockEntities will be saved with the new format whenever the game usually saves BlockEntities (e.g. upon stopping the server), and ItemStacks will be saved with the new format whenever their `InkStorage` is modified (e.g. upon adding or removing ink).