### PR TITLE
Vanity Slots compat for BedrockCapeRenderer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ dependencies {
 	// modCompileOnly("maven.modrinth:enchantment-descriptions:${project.enchantment_descriptions_version}")
 	modCompileOnly("maven.modrinth:travelersbackpack:${project.travelers_backpack_version}")
 	modCompileOnly("maven.modrinth:botania:${project.botania_version}")
+	modCompileOnly("maven.modrinth:vanity:${project.vanityslots_version}")
 	modImplementation("maven.modrinth:idwtialsimmoedm:${project.idwtialsimmoedm_version}")
 
 	//Porting Lib

--- a/gradle.properties
+++ b/gradle.properties
@@ -65,6 +65,8 @@ port_lib_version = 2.3.5+1.20.1
 port_lib_modules = lazy_registration
 # https://modrinth.com/mod/exclusions-lib
 exclusionslib_version=0.6
+# https://modrinth.com/mod/vanity
+vanityslots_version=1.2.9
 
 # What recipe viewer to use ('emi', 'rei', or 'disabled')
 recipe_viewer=emi

--- a/src/main/java/de/dafuqs/spectrum/compat/vanityslots/VanitySlotsCompat.java
+++ b/src/main/java/de/dafuqs/spectrum/compat/vanityslots/VanitySlotsCompat.java
@@ -1,0 +1,18 @@
+package de.dafuqs.spectrum.compat.vanityslots;
+
+import gay.nyako.vanityslots.*;
+import net.fabricmc.loader.api.*;
+import net.minecraft.entity.*;
+import net.minecraft.item.*;
+
+public class VanitySlotsCompat {
+	public static final boolean IS_VANITY_SLOTS_PRESENT = FabricLoader.getInstance().isModLoaded("vanityslots");
+	
+	public static ItemStack getEquippedStack(LivingEntity entity, EquipmentSlot slot) {
+		if (VanitySlotsCompat.IS_VANITY_SLOTS_PRESENT) {
+			return VanitySlots.getEquippedStack(entity, slot);
+		} else {
+			return entity.getEquippedStack(slot);
+		}
+	}
+}

--- a/src/main/java/de/dafuqs/spectrum/mixin/client/CapeFeatureRendererMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/client/CapeFeatureRendererMixin.java
@@ -1,11 +1,11 @@
 package de.dafuqs.spectrum.mixin.client;
 
+import de.dafuqs.spectrum.compat.vanityslots.*;
 import de.dafuqs.spectrum.registries.*;
 import de.dafuqs.spectrum.render.armor.*;
 import net.fabricmc.api.*;
 import net.minecraft.client.network.*;
 import net.minecraft.client.render.*;
-import net.minecraft.client.render.entity.*;
 import net.minecraft.client.render.entity.feature.*;
 import net.minecraft.client.render.entity.model.*;
 import net.minecraft.client.util.math.*;
@@ -29,7 +29,7 @@ public abstract class CapeFeatureRendererMixin extends FeatureRenderer<AbstractC
 	@Inject(method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/client/network/AbstractClientPlayerEntity;FFFFFF)V", at = @At("HEAD"), cancellable = true)
 	public void spectrum$renderBedrockCape(MatrixStack ms, VertexConsumerProvider vertices, int light, AbstractClientPlayerEntity player, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
 		// Check for the chestplate, and begin rendering the cape if equipped
-		ItemStack chestStack = player.getEquippedStack(EquipmentSlot.CHEST);
+		ItemStack chestStack = VanitySlotsCompat.getEquippedStack(player, EquipmentSlot.CHEST);
 		if (chestStack.getItem() == SpectrumItems.BEDROCK_CHESTPLATE) {
 			BedrockCapeRenderer.renderBedrockCapeAndCloth(ms, vertices, light, player, h, chestStack);
 			// TODO - Cancel for now, as the new armor tailoring system is not implemented yet


### PR DESCRIPTION
If [Vanity Slots](https://modrinth.com/mod/vanity) is installed and the player is wearing a Bedrock Chestplate, the bedrock cape renderer now respects what the player is wearing in their "vanity" chesplate slot, instead of always rendering the bedrock cape regardless. I.e., wearing anything other than a Bedrock Chestplate in that slot will prevent the cape from rendering.

No Vanity Slots classes are loaded if Vanity Slots is not installed, so Spectrum still works as intended without it.