### PR TITLE
Avoid usage of Local in AbstractInventoryScreenMixin

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/mixin/client/AbstractInventoryScreenMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/client/AbstractInventoryScreenMixin.java
@@ -1,6 +1,5 @@
 package de.dafuqs.spectrum.mixin.client;
 
-import com.llamalad7.mixinextras.sugar.*;
 import de.dafuqs.spectrum.*;
 import de.dafuqs.spectrum.api.status_effect.*;
 import de.dafuqs.spectrum.registries.*;
@@ -9,6 +8,7 @@ import net.minecraft.entity.effect.*;
 import net.minecraft.util.*;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.*;
 
 @Mixin(AbstractInventoryScreen.class)
 public class AbstractInventoryScreenMixin {
@@ -20,16 +20,31 @@ public class AbstractInventoryScreenMixin {
 	@Unique
 	private static final Identifier DIVINITY_EFFECT_BACKGROUNDS = SpectrumCommon.locate("textures/gui/divinity_effect_backgrounds.png");
 
+	@Unique
+	private StatusEffectInstance effect;
+
+	@ModifyVariable(method = "drawStatusEffectBackgrounds", at = @At("STORE"))
+	public StatusEffectInstance storeEffect(StatusEffectInstance value) {
+		this.effect = value;
+		return value;
+	}
+
 	@ModifyArg(method = "drawStatusEffectBackgrounds", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V", ordinal = 0))
-	public Identifier modifyWideBackground(Identifier texture, @Local StatusEffectInstance effect) {
-		return getTexture(texture, effect);
+	public Identifier modifyWideBackground(Identifier texture) {
+		return getTexture(texture, this.effect);
 	}
 
 	@ModifyArg(method = "drawStatusEffectBackgrounds", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V", ordinal = 1))
-	public Identifier modifyBackground(Identifier texture, @Local StatusEffectInstance effect) {
-		return getTexture(texture, effect);
+	public Identifier modifyBackground(Identifier texture) {
+		return getTexture(texture, this.effect);
 	}
 
+	@Inject(method = "drawStatusEffectBackgrounds", at = @At("TAIL"))
+	private void nullifyEffect(CallbackInfo ci) {
+		this.effect = null;
+	}
+
+	@Unique
 	private static Identifier getTexture(Identifier texture, StatusEffectInstance effect) {
 		var type = effect.getEffectType();
 


### PR DESCRIPTION
Fixes a weird crash during startup in AOF7. Tested and working. (well, it works the same as upstream Spectrum, anyway)