### PR TITLE
remove unnecessary `#botania:rods` tag

### DIFF
--- a/src/main/resources/data/botania/tags/items/rods.json
+++ b/src/main/resources/data/botania/tags/items/rods.json
@@ -1,6 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "#spectrum:trinkets"
-  ]
-}


### PR DESCRIPTION
since https://github.com/VazkiiMods/Botania/commit/9f5751630a32ae3f1b6f3e9a0d51af053ee4bbcc all trinkets can go in botania's trinket case, so this tag addition is no longer necessary