### PR TITLE
Only replace targeted tables in Farmer's Delight compat

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/compat/farmersdelight/FDCompat.java
+++ b/src/main/java/de/dafuqs/spectrum/compat/farmersdelight/FDCompat.java
@@ -16,7 +16,7 @@ public class FDCompat extends SpectrumIntegrationPacks.ModIntegrationPack {
 			if (AMARANTH_LOOT_TABLE_ID.equals(id)) {
 				return lootManager.getLootTable(FD_AMARANTH_LOOT_TABLE_ID);
 			}
-			return original;
+			return null;
 		});
 	}
 	


### PR DESCRIPTION
The Farmer's Delight compat uses `LootTableEvents.REPLACE`. In the current implementation it returns the original table if unchanged. However this causes the Fabric API to mark all loot tables processed by this function as replaced, which means mods that check the table source so that they only modify the builtin tables fail silently. This problem was discovered with Scriptor Magicae, but likely also affects other mods.

The fix is simply to return null if the table is unchanged. The Fabric API expects this behaviour and handles it appropriately.