### PR TITLE
Use StatusEffectInstance.amplifier getter method + update build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,20 +18,15 @@ jobs:
     
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
-      
-      - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: actions/checkout@v4
       
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
       
-      - name: make gradle wrapper executable
-        # Linux requires that files are marked executable
-        if: ${{ runner.os != 'Windows' }}
-        run: chmod +x ./gradlew
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v4
       
       - name: build
         run: ./gradlew build
@@ -43,5 +38,3 @@ jobs:
         with:
           name: Artifacts
           path: build/libs/
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: microsoft
       
       - name: setup gradle
         uses: gradle/actions/setup-gradle@v4

--- a/src/main/java/de/dafuqs/spectrum/registries/SpectrumEventListeners.java
+++ b/src/main/java/de/dafuqs/spectrum/registries/SpectrumEventListeners.java
@@ -230,7 +230,7 @@ public class SpectrumEventListeners {
 						.stream()
 						.filter(instance -> {
 							AtomicBoolean result = new AtomicBoolean(false);
-							instance.getEffectType().value().forEachAttributeModifier(instance.amplifier, (attribute, modifier) -> {
+							instance.getEffectType().value().forEachAttributeModifier(instance.getAmplifier(), (attribute, modifier) -> {
 								if (attribute.isIn(effectType))
 									result.set(true);
 							});


### PR DESCRIPTION
`StatusEffectInstance.amplifier` is private by default, so it's likely that Spectrum compiles against a mod that widens its access - but not transitively, hence this causing a crash when reached during runtime.

The build workflow has also been updated, as it looks like GitHub / Gradle have finally deprecated `gradle/wrapper-validation-action@v1`.