### PR TITLE
Tweaks for recent primfire changes

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/sound/OnPrimordialFireSoundInstance.java
+++ b/src/main/java/de/dafuqs/spectrum/sound/OnPrimordialFireSoundInstance.java
@@ -16,7 +16,7 @@ public class OnPrimordialFireSoundInstance extends AbstractSoundInstance impleme
 		super(SpectrumSoundEvents.PRIMORDIAL_FIRE_DOT, SoundSource.PLAYERS, player.getRandom());
 		this.looping = true;
 		this.delay = 0;
-		this.volume = 0.05F;
+		this.volume = 0.2F;
 		this.player = player;
 		this.relative = true;
 	}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_enchantments.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_enchantments.json
@@ -2,6 +2,7 @@
   "values": [
     "spectrum:dragonrot",
     "spectrum:irradiance",
+    "spectrum:primordial_fire",
     "spectrum:set_health"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/damage_type/is_fire.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/is_fire.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "spectrum:kindling_cough",
-    "spectrum:primordial_fire"
+    "spectrum:kindling_cough"
   ]
 }

--- a/src/main/resources/data/spectrum/damage_type/primordial_fire.json
+++ b/src/main/resources/data/spectrum/damage_type/primordial_fire.json
@@ -1,5 +1,6 @@
 {
   "exhaustion": 0.0,
   "message_id": "spectrum_primordial_fire",
-  "scaling": "never"
+  "scaling": "never",
+  "effects": "burning"
 }


### PR DESCRIPTION
- Restores primfire damage's ability to bypass enchantments
- Makes hits from primfire damage play the fire-hurt noise instead of the default one
- Increases the volume of the on-primfire noise now that you're also hearing hit sounds while ignited
- Removes primfire damage from the `is_fire` tag

The last change there is because using `is_fire` caused quite a few problems (most notably making nether mobs, anything with fire res, and anything wearing an ashen circlet completely ignore primfire) and didn't really improve anything.