### PR TITLE
Connector patch

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/mixin/client/InGameHudMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/client/InGameHudMixin.java
@@ -4,7 +4,6 @@ import com.llamalad7.mixinextras.injector.*;
 import com.llamalad7.mixinextras.sugar.*;
 import de.dafuqs.spectrum.helpers.*;
 import de.dafuqs.spectrum.registries.*;
-import de.dafuqs.spectrum.render.*;
 import de.dafuqs.spectrum.status_effects.*;
 import net.minecraft.client.*;
 import net.minecraft.client.gui.*;
@@ -19,20 +18,10 @@ import org.spongepowered.asm.mixin.injection.callback.*;
 public abstract class InGameHudMixin {
 	
 	@Shadow
-	@Final
-	private Minecraft minecraft;
-	
-	@Shadow
 	protected abstract Player getCameraPlayer();
 	
 	@Shadow
 	public abstract void render(GuiGraphics context, DeltaTracker tickerCounter);
-	
-	@Inject(method = "renderPlayerHealth", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V"))
-	private void spectrum$renderAzureDikeBar(GuiGraphics context, CallbackInfo ci, @Local Player cameraPlayer, @Local(ordinal = 2) int x, @Local(ordinal = 4) int y, @Local(ordinal = 6) int heartRows, @Local(ordinal = 7) int rowHeight) {
-		minecraft.getProfiler().popPush("spectrum:azure");
-        HudRenderers.renderAzureDike(context, cameraPlayer, x, y - (heartRows - 1) * rowHeight - 10);
-    }
 	
 	@ModifyExpressionValue(method = "renderCameraOverlays", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;useFancyGraphics()Z"))
 	private boolean spectrum$disableVignietteInDimension(boolean original) {

--- a/src/main/java/de/dafuqs/spectrum/mixin/compat/connector/absent/InGameHudMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/compat/connector/absent/InGameHudMixin.java
@@ -1,0 +1,22 @@
+package de.dafuqs.spectrum.mixin.compat.connector.absent;
+
+import com.llamalad7.mixinextras.sugar.*;
+import de.dafuqs.spectrum.render.*;
+import net.minecraft.client.*;
+import net.minecraft.client.gui.*;
+import net.minecraft.world.entity.player.*;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.*;
+
+@Mixin(Gui.class)
+public class InGameHudMixin {
+	
+	@Shadow @Final private Minecraft minecraft;
+	
+	@Inject(method = "renderPlayerHealth", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V"))
+	private void spectrum$renderAzureDikeBar(GuiGraphics context, CallbackInfo ci, @Local Player cameraPlayer, @Local(ordinal = 2) int x, @Local(ordinal = 4) int y, @Local(ordinal = 6) int heartRows, @Local(ordinal = 7) int rowHeight) {
+		minecraft.getProfiler().popPush("spectrum:azure");
+		HudRenderers.renderAzureDike(context, cameraPlayer, x, y - (heartRows - 1) * rowHeight - 10);
+	}
+}

--- a/src/main/java/de/dafuqs/spectrum/mixin/compat/connector/present/InGameHudMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/compat/connector/present/InGameHudMixin.java
@@ -1,0 +1,25 @@
+package de.dafuqs.spectrum.mixin.compat.connector.present;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import de.dafuqs.spectrum.render.HudRenderers;
+import net.minecraft.client.*;
+import net.minecraft.client.gui.*;
+import net.minecraft.world.entity.player.*;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Gui.class)
+public class InGameHudMixin {
+	
+	@Shadow @Final private Minecraft minecraft;
+	
+	@Inject(method = "renderPlayerHealth", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V"))
+	private void spectrum$renderAzureDikeBar(GuiGraphics context, CallbackInfo ci, @Local Player cameraPlayer, @Local(ordinal = 3) int x, @Local(ordinal = 5) int y, @Local(ordinal = 7) int heartRows, @Local(ordinal = 8) int rowHeight) {
+		minecraft.getProfiler().popPush("spectrum:azure");
+		HudRenderers.renderAzureDike(context, cameraPlayer, x, y - (heartRows - 1) * rowHeight - 10);
+	}
+}


### PR DESCRIPTION
Another patch for Sinytra Connector compatibility. While Spectrum itself has only one conflict I have found so far, there are a couple among its dependencies (including one caused by an issue in Forgified Fabric API), which I am working on fixing. To run Spectrum on Connector for 1.21.1 as of now, my fork of FFAPI is required, in addition to a NeoForge port of Exclusions Lib which I am in the process of making (I have something that works currently, but it _only_ runs on Connector at this time).
There is at least one graphical bug, which likely has something to do with Fractal. The background of the icon for the Spectrum creative tab appears to be upside down when the tab is on the top row (I have not tested it with the tab on the bottom row).