### PR TITLE
Fixing prolonging not prolonging effect as expected.

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/status_effects/EffectProlongingStatusEffect.java
+++ b/src/main/java/de/dafuqs/spectrum/status_effects/EffectProlongingStatusEffect.java
@@ -17,7 +17,7 @@ public class EffectProlongingStatusEffect extends MobEffect {
 	}
 	
 	public static int getExtendedDuration(int originalDuration, int prolongingAmplifier) {
-		return (int) (originalDuration * (1 + ADDITIONAL_EFFECT_DURATION_MODIFIER_PER_LEVEL * prolongingAmplifier));
+		return (int) (originalDuration * (1 + ADDITIONAL_EFFECT_DURATION_MODIFIER_PER_LEVEL * (1 + prolongingAmplifier)));
 	}
 	
 }


### PR DESCRIPTION
In Minecraft,the Amplifier of an effect is actually its level-1,making this will return originalDuration while you only have a level 1 prolonging...