### PR TITLE
fix: Bottomless Bundle annoying dupe

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
@@ -422,7 +422,7 @@ public class BottomlessBundleItem extends BlockItem implements InventoryInsertio
 			}
 			
 			public int add(ItemStack stack) {
-				if (this.count != 0 && this.variant != ItemVariant.of(stack)) {
+				if (!this.isEmpty() && !this.variant.matches(stack)) {
 					return 0;
 				}
 
@@ -457,7 +457,7 @@ public class BottomlessBundleItem extends BlockItem implements InventoryInsertio
 			}
 			
 			public long add(Slot slot, Player player) {
-				if (this.count != 0 && this.variant != ItemVariant.of(slot.getItem())) {
+				if (!this.isEmpty() && !this.variant.matches(slot.getItem())) {
 					return 0;
 				}
 				var maxAllowed = this.getMaxAllowed(slot.getItem());

--- a/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/bottomless_bundle/BottomlessBundleItem.java
@@ -422,6 +422,10 @@ public class BottomlessBundleItem extends BlockItem implements InventoryInsertio
 			}
 			
 			public int add(ItemStack stack) {
+				if (this.count != 0 && this.variant != ItemVariant.of(stack)) {
+					return 0;
+				}
+
 				int toAdd = Math.min(stack.getCount(), this.getMaxAllowed(stack));
 				if (toAdd == 0)
 					return 0;
@@ -453,6 +457,9 @@ public class BottomlessBundleItem extends BlockItem implements InventoryInsertio
 			}
 			
 			public long add(Slot slot, Player player) {
+				if (this.count != 0 && this.variant != ItemVariant.of(slot.getItem())) {
+					return 0;
+				}
 				var maxAllowed = this.getMaxAllowed(slot.getItem());
 				return this.add(slot.safeTake(slot.getItem().getCount(), maxAllowed, player));
 			}


### PR DESCRIPTION
On current version you can convert any insertable in bottomless bundle item into any other insertable item
For example convert dozens of dirt into diamond blocks
Or accidently put your fully upgraded glove into bundle with dirt, and get one more dirt...

Changes:
- Bundle now checks that it can consume itemstack type before addiung it to botomless stack

Build:
You can check build [on separate branch in gh actions](https://github.com/EgrorBs/Spectrum/actions/runs/15999889629)