### PR TITLE
fix: Dirty fix of crash when upgrading modular explosive

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/explosion/ModularExplosionDefinition.java
+++ b/src/main/java/de/dafuqs/spectrum/explosion/ModularExplosionDefinition.java
@@ -17,6 +17,7 @@ import net.minecraft.world.item.*;
 import org.jetbrains.annotations.*;
 
 import java.util.*;
+import java.lang.*;
 
 /**
  * A Set of ExplosionModifiers
@@ -51,6 +52,14 @@ public class ModularExplosionDefinition {
 	public static ModularExplosionDefinition getFromStack(ItemStack stack) {
 		return stack.getOrDefault(SpectrumDataComponentTypes.MODULAR_EXPLOSION, new ModularExplosionDefinition());
 	}
+
+	public static ModularExplosionDefinition clone(ModularExplosionDefinition original) {
+		return new ModularExplosionDefinition(original.archetype, new ArrayList<ExplosionModifier>(original.modifiers));
+	}
+
+	public static ModularExplosionDefinition cloneFromStack(ItemStack stack) {
+		return clone(getFromStack(stack));
+	}
 	
 	public static void removeFromStack(ItemStack stack) {
 		stack.remove(SpectrumDataComponentTypes.MODULAR_EXPLOSION);
@@ -73,7 +82,14 @@ public class ModularExplosionDefinition {
 	}
 	
 	public void addModifiers(List<ExplosionModifier> modifiers) {
-		this.modifiers.addAll(modifiers);
+		try {
+			this.modifiers.addAll(modifiers);
+		} catch (java.lang.UnsupportedOperationException e) { // `modifiers` collection actually may be ImmutableCollection
+			var newModifiers = new ArrayList<ExplosionModifier>();
+			newModifiers.addAll(this.modifiers);
+			newModifiers.addAll(modifiers);
+			this.modifiers = newModifiers;
+		}
 	}
 	
 	public ExplosionArchetype getArchetype() {

--- a/src/main/java/de/dafuqs/spectrum/recipe/pedestal/dynamic/ExplosionModificationRecipe.java
+++ b/src/main/java/de/dafuqs/spectrum/recipe/pedestal/dynamic/ExplosionModificationRecipe.java
@@ -46,7 +46,7 @@ public class ExplosionModificationRecipe extends ShapelessPedestalRecipe {
 		}
 		
 		Pair<List<ExplosionArchetype>, List<ExplosionModifier>> pair = findArchetypeAndModifiers(inventory);
-		ModularExplosionDefinition currentSet = ModularExplosionDefinition.getFromStack(nonModStack);
+		ModularExplosionDefinition currentSet = ModularExplosionDefinition.cloneFromStack(nonModStack);
 		List<ExplosionArchetype> archetypes = pair.getFirst();
 		List<ExplosionModifier> mods = pair.getSecond();
 		
@@ -103,7 +103,7 @@ public class ExplosionModificationRecipe extends ShapelessPedestalRecipe {
 			return output;
 		}
 		
-		ModularExplosionDefinition set = ModularExplosionDefinition.getFromStack(output);
+		ModularExplosionDefinition set = ModularExplosionDefinition.cloneFromStack(output);
 		
 		// adding new modifiers
 		if (!archetypes.isEmpty()) {


### PR DESCRIPTION
When you try to add TNT to manually crafted (not from EMI) modular explosive you got crash

Changes:
 - dirty try-catch around throwing method and alternative code to clone immutable collection instead
 - couple methods to clone information from itemstack instead of just getting it (cuz after first fix modifiers stack as crazy even when craft not yet started)

I thing this is problem related to NBT to Component migration, don't sure

I think my fix is OK, but i don't sure, at least it don't crash anymore...

Build:
You can get ci build on [separate branch in gh actions](https://github.com/EgrorBs/Spectrum/actions/runs/16000029175)

Crash report stack trace (before my fix):
```
java.lang.UnsupportedOperationException
	at java.base/java.util.ImmutableCollections.uoe(ImmutableCollections.java:142)
	at java.base/java.util.ImmutableCollections$AbstractImmutableCollection.addAll(ImmutableCollections.java:148)
	at knot//de.dafuqs.spectrum.explosion.ModularExplosionDefinition.addModifiers(ModularExplosionDefinition.java:76)
	at knot//de.dafuqs.spectrum.recipe.pedestal.dynamic.ExplosionModificationRecipe.matches(ExplosionModificationRecipe.java:67)
	at knot//de.dafuqs.spectrum.recipe.pedestal.dynamic.ExplosionModificationRecipe.method_8115(ExplosionModificationRecipe.java:22)
	at knot//net.minecraft.class_1863.method_42301(class_1863.java:96)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1034)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at knot//net.minecraft.class_1863.method_59993(class_1863.java:96)
	at knot//net.minecraft.class_1863.method_8132(class_1863.java:81)
	at knot//de.dafuqs.spectrum.blocks.pedestal.PedestalBlockEntity.calculateRecipe(PedestalBlockEntity.java:300)
	at knot//de.dafuqs.spectrum.blocks.pedestal.PedestalBlockEntity.serverTick(PedestalBlockEntity.java:150)
	at knot//net.minecraft.class_2818$class_5563.method_31703(class_2818.java:691)
	at knot//net.minecraft.class_2818$class_5564.method_31703(class_2818.java:745)
	at knot//net.minecraft.class_1937.method_18471(class_1937.java:488)
	at knot//net.minecraft.class_3218.method_18765(class_3218.java:413)
	at knot//net.minecraft.server.MinecraftServer.method_3813(MinecraftServer.java:1021)
	at knot//net.minecraft.server.MinecraftServer.method_3748(MinecraftServer.java:912)
	at knot//net.minecraft.class_1132.method_3748(class_1132.java:114)
	at knot//net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:697)
	at knot//net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:281)
	at java.base/java.lang.Thread.run(Thread.java:1583)

-- Block entity being ticked --
Details:
	Name: spectrum:pedestal_block_entity // de.dafuqs.spectrum.blocks.pedestal.PedestalBlockEntity
	Block: Block{spectrum:pedestal_basic_amethyst}[powered=false]
	Block location: World: (118,67,2504), Section: (at 6,3,8 in 7,4,156; chunk contains blocks 112,-64,2496 to 127,319,2511), Region: (0,4; contains chunks 0,128 to 31,159, blocks 0,-64,2048 to 511,319,2559)
	Block: Block{spectrum:pedestal_basic_amethyst}[powered=false]
	Block location: World: (118,67,2504), Section: (at 6,3,8 in 7,4,156; chunk contains blocks 112,-64,2496 to 127,319,2511), Region: (0,4; contains chunks 0,128 to 31,159, blocks 0,-64,2048 to 511,319,2559)
	Block Entity NBT: {CraftingTime:0s,CraftingTimeTotal:40s,Items:[{Slot:4b,components:{"spectrum:modular_explosion":{archetype:"destroy_blocks"}},count:1,id:"spectrum:parametric_mining_device"},{Slot:5b,count:1,id:"minecraft:tnt"},{Slot:9b,count:55,id:"spectrum:topaz_powder"},{Slot:10b,count:64,id:"spectrum:amethyst_powder"},{Slot:11b,count:7,id:"spectrum:citrine_powder"}],OwnerUUID:[I;-1825683409,897467261,-1512549187,2120786961],StoredXP:0.5f,Upgrades:[],inventory_changed:1b,unloaded_activity:{last_tick:22996747L}}
```