### PR TITLE
Fix pastel network

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/network/ServerPastelNetwork.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/network/ServerPastelNetwork.java
@@ -44,7 +44,7 @@ public class ServerPastelNetwork extends PastelNetwork<ServerLevel> {
 	}
 	
 	public ServerPastelNetwork(ServerLevel world, PastelNodeBlockEntity initialNode) {
-		this(world, initialNode.getNodeId(), initialNode.getPastelNetworkColor(), new TickLooper(10));
+		this(world, UUID.randomUUID(), initialNode.getPastelNetworkColor(), new TickLooper(10));
 		addNode(initialNode);
 	}
 	

--- a/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/network/ServerPastelNetworkManager.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/network/ServerPastelNetworkManager.java
@@ -61,6 +61,7 @@ public class ServerPastelNetworkManager extends SavedData implements PastelNetwo
 				var wrapper = new CompoundTag();
 				wrapper.put("network", opt.get());
 				wrapper.put("scheduler", transgender(network.getTransmissions()));
+				wrapper.put("graph", network.graphToNbt());
 				// Trans missions?... do... do they really?
 				networkList.add(wrapper);
 			}
@@ -75,10 +76,12 @@ public class ServerPastelNetworkManager extends SavedData implements PastelNetwo
 			var comp = (CompoundTag) element;
 			var netNbt = comp.get("network");
 			var schedulerNbt = comp.getCompound("scheduler");
+			var graphNbt = comp.getCompound("graph");
 			
 			Optional<ServerPastelNetwork> network = CodecHelper.fromNbt(ServerPastelNetwork.CODEC, netNbt);
 			if (network.isPresent()) {
 				network.get().getTransmissions().putAll(transDecode(schedulerNbt, network.get()));
+				network.get().setGraph(ServerPastelNetwork.graphFromNbt(graphNbt));
 				manager.networks.add(network.get());
 			}
 		}

--- a/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlock.java
@@ -168,6 +168,8 @@ public class PastelNodeBlock extends SpectrumFacingBlock implements EntityBlock,
 			
 			world.playLocalSound(pos, SpectrumSoundEvents.MEDIUM_CRYSTAL_RING, SoundSource.BLOCKS, 0.25F, 0.9F + world.getRandom().nextFloat() * 0.2F, true);
 			return ItemInteractionResult.sidedSuccess(world.isClientSide());
+		} else if (tryColorUsingStackInHand(stack, world, pos, player, hand)) {
+			return ItemInteractionResult.sidedSuccess(world.isClientSide());
 		} else if (this.pastelNodeType.usesFilters()) {
 			if (!world.isClientSide) {
 				player.openMenu(blockEntity);

--- a/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlockEntity.java
@@ -340,6 +340,7 @@ public class PastelNodeBlockEntity extends BlockEntity implements FilterConfigur
 		this.creationStamp = nbt.contains("creationStamp") ? nbt.getLong("creationStamp") : 0;
 		this.lastTransferTick = nbt.contains("LastTransferTick", Tag.TAG_LONG) ? nbt.getLong("LastTransferTick") : 0;
 		this.itemCountUnderway = nbt.contains("ItemCountUnderway", Tag.TAG_LONG) ? nbt.getLong("ItemCountUnderway") : 0;
+		this.color = nbt.contains("ColorId", Tag.TAG_INT) ? Optional.of(DyeColor.byId(nbt.getInt("ColorId"))) : Optional.empty();
 		this.outerRing = nbt.contains("OuterRing") ? Optional.ofNullable(SpectrumRegistries.PASTEL_UPGRADE.get(ResourceLocation.tryParse(nbt.getString("OuterRing")))) : Optional.empty();
 		this.innerRing = nbt.contains("InnerRing") ? Optional.ofNullable(SpectrumRegistries.PASTEL_UPGRADE.get(ResourceLocation.tryParse(nbt.getString("InnerRing")))) : Optional.empty();
 		this.redstoneRing = nbt.contains("RedstoneRing") ? Optional.ofNullable(SpectrumRegistries.PASTEL_UPGRADE.get(ResourceLocation.tryParse(nbt.getString("RedstoneRing")))) : Optional.empty();
@@ -357,6 +358,9 @@ public class PastelNodeBlockEntity extends BlockEntity implements FilterConfigur
 		}
 		if (this.networkUUID.isPresent()) {
 			nbt.putUUID("NetworkUUID", this.networkUUID.get());
+		}
+		if (this.color.isPresent()) {
+			nbt.putInt("ColorId", this.color.get().getId());
 		}
 		nbt.putUUID("NodeID", this.nodeId);
 		nbt.putBoolean("Triggered", this.triggered);

--- a/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlockEntity.java
@@ -74,6 +74,8 @@ public class PastelNodeBlockEntity extends BlockEntity implements FilterConfigur
 	
 	protected BlockApiCache<Storage<ItemVariant>, Direction> connectedStorageCache = null;
 	protected Direction cachedDirection = null;
+
+	protected Boolean isInitialized = false;
 	
 	private final List<ItemVariant> filterItems;
 	float rotationTarget, crystalRotation, lastRotationTarget, heightTarget, crystalHeight, lastHeightTarget, alphaTarget, ringAlpha, lastAlphaTarget;
@@ -101,6 +103,11 @@ public class PastelNodeBlockEntity extends BlockEntity implements FilterConfigur
 	}
 	
 	public static void tick(@NotNull Level world, BlockPos pos, BlockState state, PastelNodeBlockEntity node) {
+		if (!node.isInitialized && !world.isClientSide()) { // kinda onLoad()?
+			node.getServerNetwork().ifPresent(network -> network.initializeNode(node));
+			node.isInitialized = true;
+		}
+
 		if (node.lamp && state.getValue(BlockStateProperties.LIT) != node.canTransfer()) {
 			world.setBlockAndUpdate(pos, state.setValue(BlockStateProperties.LIT, node.cachedUnpowered));
 		}
@@ -546,6 +553,7 @@ public class PastelNodeBlockEntity extends BlockEntity implements FilterConfigur
 	public void connectToNearbyNodes(@Nullable Entity user) {
 		// remove from existing network, if it had one and join new networks
 		Pastel.getServerInstance().removeNode(this, NodeRemovalReason.DISCONNECT);
+		this.setNetworkUUID(null);
 		
 		// scan for all connectable nearby nodes
 		Map<Optional<ServerPastelNetwork>, List<PastelNodeBlockEntity>> connectableNodes = new Object2ObjectArrayMap<>();
@@ -584,7 +592,12 @@ public class PastelNodeBlockEntity extends BlockEntity implements FilterConfigur
 			
 			network = Pastel.getServerInstance().createNetwork((ServerLevel) level, this);
 			for (PastelNodeBlockEntity entry : connectableNodes.get(Optional.empty())) {
-				network.addEdge(this, entry);
+				try {
+					network.addEdge(this, entry); // Sometimes throws 'IllegalStateException("Attempted to add an edge to a foreign network")' (why? idk. better safe than sorry)
+				} catch (Exception e) {
+					SpectrumCommon.logWarning("PastelNodeBlockEntity can't connectToNearbyNodes: " + e.getMessage());
+					e.printStackTrace();
+				}
 			}
 		} else if (foundNetworkCount == 1) {
 			// there is exactly one other network

--- a/src/main/java/de/dafuqs/spectrum/items/magic_items/PaintbrushItem.java
+++ b/src/main/java/de/dafuqs/spectrum/items/magic_items/PaintbrushItem.java
@@ -134,7 +134,7 @@ public class PaintbrushItem extends Item implements SignApplicator {
 					context.getLevel().playSound(null, context.getClickedPos(), SpectrumSoundEvents.USE_FAIL, SoundSource.BLOCKS, 1.0F, 1.0F);
 				}
 			}
-			return false;
+			return true;
 		}
 		
 		return cursedColor(context);


### PR DESCRIPTION
- Information about the pastel network graphs is not saved/loaded when saving the world/chunk
- Nodes don't call `initializeNode` on loading
- When painting a node, a pastel network may be created with an already existing UUID (with old color, and attached nodes), which leads to the node's malfunction after painting/repainting
- Pastel node painting only works with slingshots, which I don't think was the intended design
- Pastel node colors are not saved

Changes:
- Graph information is now saved and loaded from spectrum_pastel_network_manager.dat (as intended, I believe)
- Node calls initializeNode as soon as it ticks for the first time (I couldn't find a reliable onLoad() method)
- Network UUID is now generated randomly
- Pastel node painting now works with either paintbrushes or pigment bottles
- Pastel node colors are now saved with the BlockEntity NBT data.
- Paintbrush's tryColorBlock() now returns true when a ColorableBlock is successfully painted (as intended, I believe)