### PR TITLE
fix: Disable 'smart' culling when looking at spyhole

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/registries/client/SpectrumClientEventListeners.java
+++ b/src/main/java/de/dafuqs/spectrum/registries/client/SpectrumClientEventListeners.java
@@ -67,6 +67,26 @@ public class SpectrumClientEventListeners {
 		registerCustomItemRenderer("omni_accelerator", SpectrumItems.OMNI_ACCELERATOR, OmniAcceleratorItem.Renderer::new);
 		
 		WorldRenderEvents.START.register(context -> HudRenderers.clearItemStackOverlay());
+
+		WorldRenderEvents.START.register(context -> {
+			Minecraft client = Minecraft.getInstance();
+			if (client.player != null) {
+				Boolean newSmartCull;
+				if (client.hitResult instanceof BlockHitResult blockHitResult &&
+						client.player.level().getBlockState(blockHitResult.getBlockPos())
+								.getBlock() == SpectrumBlocks.UNIVERSE_SPYHOLE) {
+					newSmartCull = false;
+				} else {
+					newSmartCull = true;
+				}
+				if (client.smartCull != newSmartCull) {
+					client.smartCull = newSmartCull;
+					if (newSmartCull == false) {
+						client.levelRenderer.needsUpdate(); // we need to draw caves etc...
+					}
+				}
+			}
+		});
 		
 		WorldRenderEvents.AFTER_ENTITIES.register(context -> ((ExtendedParticleManager) Minecraft.getInstance().particleEngine).render(context.matrixStack(), context.consumers(), context.camera(), context.tickCounter().getGameTimeDeltaPartialTick(true)));
 		WorldRenderEvents.AFTER_TRANSLUCENT.register(context -> {


### PR DESCRIPTION
Implementation feels suboptimal, but I can’t think of a better way

This should partially resolve #746, but only when you’re looking directly through a spyhole (or shortly afterward)

![image](https://github.com/user-attachments/assets/352e9314-033d-4a6d-8239-7b9f5900dca8)
![image](https://github.com/user-attachments/assets/4f22de36-ba83-47f1-a27c-3248932855b9)
