### PR TITLE
prevent ring gravity effects while creative flying

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/api/item/GravitableItem.java
+++ b/src/main/java/de/dafuqs/spectrum/api/item/GravitableItem.java
@@ -22,7 +22,7 @@ public interface GravitableItem {
 		if (world != null && entity != null) {
 			// don't affect creative/spectators/... players or immune boss mobs
 			if (entity.isPushable() && !entity.isNoGravity() && !entity.isSpectator()) {
-				if (entity instanceof Player player && player.isCreative()) {
+				if (entity instanceof Player player && player.getAbilities().flying) {
 					return 0;
 				}
 


### PR DESCRIPTION
this fixes an issue that would cause the ring of aetherial grace to make you slowly rise into the air while creative flying in survival through other mods