### PR TITLE
Fixed Nightdew cannot grow after broken by Block Breaker

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockBreakerBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockBreakerBlock.java
@@ -106,10 +106,12 @@ public class BlockBreakerBlock extends RedstoneInteractionBlock implements Entit
 		if (BREAK_STACK == null) { // we initialize the item here instead of it being final because of load order shenanigans
 			BREAK_STACK = new ItemStack(SpectrumItems.MALACHITE_WORKSTAFF);
 		}
+		Block block = blockState.getBlock();
 		Block.dropResources(blockState, world, pos, blockEntity, breaker, BREAK_STACK);
 		
 		if (world.setBlock(pos, fluidState.createLegacyBlock(), Block.UPDATE_ALL, 512)) {
 			world.gameEvent(GameEvent.BLOCK_DESTROY, pos, GameEvent.Context.of(breaker, blockState));
+			block.destroy(world, pos, blockState);
 		}
 	}
 	


### PR DESCRIPTION
Nightdews, or `TriStateVineBlock`s, set the block state of the block above it in Block.destroy(), to make the vine can continue to grow. But this method is not invoked after being broken by Block Breaker, making the vine cannot grow. This PR should fix this.

However, it is still recommended to refactor `TriStateVineBlock` class, as Block.destroy() is not always called after a block is destroyed. For example, after an explosion, the lowest vine block's `life_stage` is still `stalk`, making the vine cannot grow after surviving the explosion.