### PR TITLE
When Mutandis rolling becomes a game of Roulette 

### DIFF
--- a/src/main/resources/data/enchanted/tags/blocks/mutandis_blacklist.json
+++ b/src/main/resources/data/enchanted/tags/blocks/mutandis_blacklist.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "#spectrum:colored_saplings",
+    "spectrum:resonant_lily",
+    "spectrum:sweet_pea",
+    "spectrum:apricotti",
+    "spectrum:humming_bell",
+    "spectrum:ominous_sapling"
+  ]
+}

--- a/src/main/resources/data/enchanted/tags/blocks/mutandis_extremis_blacklist.json
+++ b/src/main/resources/data/enchanted/tags/blocks/mutandis_extremis_blacklist.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "#spectrum:colored_saplings",
+    "spectrum:resonant_lily",
+    "spectrum:sweet_pea",
+    "spectrum:apricotti",
+    "spectrum:humming_bell",
+    "spectrum:ominous_sapling"
+  ]
+}


### PR DESCRIPTION
- Added (by hand) all of Spectrums' small flowers and saplings to both mutandis Blacklisted (Except for the Doombloom)
 - Doombloom was excluded by user suggestion. (I guess we do a bit of trolling; Problem?)
 
Fixes issue regarding Enchantment Mutandis referencing #minecraft:small_flowers and #minecraft:saplings; resulting in Spectrum stuff in those to occur (including the Omnious Sapling). Left in Doombloom for comical reasons (hope you're not trying to get Rowan and Alder trees while near your valuables :3 )