### PR TITLE
Allow most integration packs to run on Forge

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/compat/SpectrumIntegrationPacks.java
+++ b/src/main/java/de/dafuqs/spectrum/compat/SpectrumIntegrationPacks.java
@@ -35,18 +35,19 @@ public class SpectrumIntegrationPacks {
 		}
 	}
 	
-	public static final String CONNECTOR_ID = "connectormod";
-	public static final String AE2_ID = "ae2";
-	public static final String GOBBER_ID = "gobber2";
-	public static final String ALLOY_FORGERY_ID = "alloy_forgery";
-	public static final String TRAVELERS_BACKPACK_ID = "travelersbackpack";
-	public static final String BOTANIA_ID = "botania";
+	public static final boolean CONNECTOR_LOADED = FabricLoader.getInstance().isModLoaded("connectormod");
+	public static final String EXCLUSIONS_LIB_ID = "exclusions_lib";
 	public static final String MODONOMICON_ID = "modonomicon";
+	
+	public static final String AE2_ID = "ae2";
+	public static final String ALLOY_FORGERY_ID = "alloy_forgery";
+	public static final String BOTANIA_ID = "botania";
 	public static final String CREATE_ID = "create";
 	public static final String FARMERSDELIGHT_ID = "farmersdelight";
-	public static final String NEEPMEAT_ID = "neepmeat";
+	public static final String GOBBER_ID = "gobber2";
 	public static final String MALUM_ID = "malum";
-	public static final String EXCLUSIONS_LIB_ID = "exclusions_lib";
+	public static final String NEEPMEAT_ID = "neepmeat";
+	public static final String TRAVELERS_BACKPACK_ID = "travelersbackpack";
 
 	@SuppressWarnings("Convert2MethodRef")
 	public static void register() {
@@ -56,18 +57,20 @@ public class SpectrumIntegrationPacks {
 			ExclusionsLibCompat.registerNotPresent();
 		}
 		
-		if (!FabricLoader.getInstance().isModLoaded(CONNECTOR_ID)) {
-			// Connector on forge causes a lot of issues since most
-			// code bases of forge mods differ quite a lot from their fabric counterparts
-			registerIntegrationPack(AE2_ID, () -> new AE2Compat());
-			registerIntegrationPack(GOBBER_ID, () -> new GobberCompat());
-			registerIntegrationPack(ALLOY_FORGERY_ID, () -> new AlloyForgeryCompat());
-			registerIntegrationPack(BOTANIA_ID, () -> new BotaniaCompat());
-			registerIntegrationPack(NEEPMEAT_ID, () -> new NEEPMeatCompat());
-			registerIntegrationPack(FARMERSDELIGHT_ID, () -> new FDCompat());
-			registerIntegrationPack(MALUM_ID, () -> new MalumCompat());
+		registerIntegrationPack(AE2_ID, () -> new AE2Compat());
+		registerIntegrationPack(ALLOY_FORGERY_ID, () -> new AlloyForgeryCompat());
+		registerIntegrationPack(BOTANIA_ID, () -> new BotaniaCompat());
+		registerIntegrationPack(CREATE_ID, () -> new CreateCompat());
+		registerIntegrationPack(FARMERSDELIGHT_ID, () -> new FDCompat());
+		registerIntegrationPack(GOBBER_ID, () -> new GobberCompat());
+		registerIntegrationPack(MALUM_ID, () -> new MalumCompat());
+		registerIntegrationPack(NEEPMEAT_ID, () -> new NEEPMeatCompat());
+		
+		if (!CONNECTOR_LOADED) {
+			// Traveler's Backpack for Forge crashes due to Fabric lacking Fluid#getFluidType (a Forge method)
+			// This cannot be reasonably worked around AFAIK
+			// ~unilock, 2025
 			registerIntegrationPack(TRAVELERS_BACKPACK_ID, () -> new TravelersBackpackCompat());
-			registerIntegrationPack(CREATE_ID, () -> new CreateCompat());
 		}
 		
 		for (ModIntegrationPack container : INTEGRATION_PACKS.values()) {

--- a/src/main/java/de/dafuqs/spectrum/compat/create/CreateCompat.java
+++ b/src/main/java/de/dafuqs/spectrum/compat/create/CreateCompat.java
@@ -52,15 +52,19 @@ public class CreateCompat extends SpectrumIntegrationPacks.ModIntegrationPack {
 			entries.add(PURE_ZINC_BLOCK);
 		});
 		
-        PipeCollisionEvent.FLOW.register(event -> {
-            final BlockState result = handleBidirectionalCollision(event.getLevel(), event.getFirstFluid(), event.getSecondFluid());
-            if (result != null) event.setState(result);
-        });
+		if (SpectrumIntegrationPacks.CONNECTOR_LOADED) {
+			// TODO
+		} else {
+			PipeCollisionEvent.FLOW.register(event -> {
+				final BlockState result = handleBidirectionalCollision(event.getLevel(), event.getFirstFluid(), event.getSecondFluid());
+				if (result != null) event.setState(result);
+			});
 
-        PipeCollisionEvent.SPILL.register(event -> {
-            final BlockState result = handleBidirectionalCollision(event.getLevel(), event.getPipeFluid(), event.getWorldFluid());
-            if (result != null) event.setState(result);
-        });
+			PipeCollisionEvent.SPILL.register(event -> {
+				final BlockState result = handleBidirectionalCollision(event.getLevel(), event.getPipeFluid(), event.getWorldFluid());
+				if (result != null) event.setState(result);
+			});
+		}
 		
 	}
 

--- a/src/main/java/de/dafuqs/spectrum/compat/emi/SpectrumEmiPlugin.java
+++ b/src/main/java/de/dafuqs/spectrum/compat/emi/SpectrumEmiPlugin.java
@@ -4,6 +4,7 @@ import de.dafuqs.spectrum.*;
 import de.dafuqs.spectrum.api.block.*;
 import de.dafuqs.spectrum.blocks.fluid.*;
 import de.dafuqs.spectrum.blocks.idols.*;
+import de.dafuqs.spectrum.compat.*;
 import de.dafuqs.spectrum.compat.emi.handlers.*;
 import de.dafuqs.spectrum.compat.emi.recipes.*;
 import de.dafuqs.spectrum.data_loaders.*;
@@ -184,7 +185,7 @@ public class SpectrumEmiPlugin implements EmiPlugin {
 		});
 		
 		//WorldInteractionRecipe
-		long amount = FabricLoader.getInstance().isModLoaded("connectormod") ? 1_000 : 81_000;
+		long amount = SpectrumIntegrationPacks.CONNECTOR_LOADED ? 1_000 : 81_000;
 		EmiStack water = EmiStack.of(Fluids.WATER, amount);
 		EmiStack lava = EmiStack.of(Fluids.LAVA, amount);
 		EmiStack dragonrot = EmiStack.of(SpectrumFluids.DRAGONROT, amount);

--- a/src/main/java/de/dafuqs/spectrum/compat/malum/MalumCompat.java
+++ b/src/main/java/de/dafuqs/spectrum/compat/malum/MalumCompat.java
@@ -1,32 +1,42 @@
 package de.dafuqs.spectrum.compat.malum;
 
-import com.sammy.malum.registry.common.item.*;
 import de.dafuqs.spectrum.api.color.*;
 import de.dafuqs.spectrum.compat.*;
 import net.fabricmc.api.*;
+import net.fabricmc.fabric.api.event.lifecycle.v1.*;
+import net.minecraft.item.*;
+import net.minecraft.registry.*;
 import net.minecraft.util.*;
 
 public class MalumCompat extends SpectrumIntegrationPacks.ModIntegrationPack {
 	
 	@Override
     public void register() {
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.MNEMONIC_FRAGMENT.get(), DyeColor.PURPLE);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.NULL_SLATE.get(), DyeColor.BLACK);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.EARTHEN_SPIRIT.get(), DyeColor.BROWN);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.INFERNAL_SPIRIT.get(), DyeColor.ORANGE);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.AERIAL_SPIRIT.get(), DyeColor.CYAN);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.AQUEOUS_SPIRIT.get(), DyeColor.LIGHT_BLUE);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.ARCANE_SPIRIT.get(), DyeColor.LIGHT_GRAY);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.SACRED_SPIRIT.get(), DyeColor.WHITE);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.ELDRITCH_SPIRIT.get(), DyeColor.GRAY);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.WICKED_SPIRIT.get(), DyeColor.BLACK);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.BLAZING_QUARTZ.get(), DyeColor.ORANGE);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.BLIGHTED_GUNK.get(), DyeColor.LIGHT_GRAY);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.MASS_OF_BLIGHTED_GUNK.get(), DyeColor.LIGHT_GRAY);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.CURSED_SAPBALL.get(), DyeColor.BROWN);
-		ItemColors.ITEM_COLORS.registerColorMapping(ItemRegistry.PROCESSED_SOULSTONE.get(), DyeColor.PURPLE);
+		// registering it late, since Malum might not have been initialized yet
+		ServerLifecycleEvents.SERVER_STARTED.register(minecraftServer -> {
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("mnemonic_fragment"), DyeColor.PURPLE);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("null_slate"), DyeColor.BLACK);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("earthen_spirit"), DyeColor.BROWN);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("infernal_spirit"), DyeColor.ORANGE);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("aerial_spirit"), DyeColor.CYAN);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("aqueous_spirit"), DyeColor.LIGHT_BLUE);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("arcane_spirit"), DyeColor.LIGHT_GRAY);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("sacred_spirit"), DyeColor.WHITE);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("eldritch_spirit"), DyeColor.GRAY);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("wicked_spirit"), DyeColor.BLACK);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("blazing_quartz"), DyeColor.ORANGE);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("blighted_gunk"), DyeColor.LIGHT_GRAY);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("mass_of_blighted_gunk"), DyeColor.LIGHT_GRAY);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("cursed_sapball"), DyeColor.BROWN);
+			ItemColors.ITEM_COLORS.registerColorMapping(getItemFromRegistry("processed_soulstone"), DyeColor.PURPLE);
+		});
 		
 		
+	}
+	
+	// Workaround to prevent loading classes from Porting Lib on Forge
+	private static Item getItemFromRegistry(String path) {
+		return Registries.ITEM.get(Identifier.of("malum", path));
 	}
 
     @Environment(EnvType.CLIENT)


### PR DESCRIPTION
Better implementation of https://github.com/DaFuqs/Spectrum/pull/793

- Fix Create and Malum integration packs to not crash with their Forge versions
  - Create's pipe interactions will require some hackery to listen to Forge events from a Fabric mod - something similar to what I originally did for QSL, probably
- Leave Traveler's Backpack disabled on Forge - its dependency on Forge's `FluidType` system cannot be easily worked around
- Sort integration packs in code (pedantic, but this has been bothering me since forever)

All integration packs not mentioned above have been tested and working on Forge by @Shibva.