### PR TITLE
Fix RedstoneInteractionBlock automatic placement

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
@@ -133,9 +133,16 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements BlockE
 	}
 	
 	public static final class BlockPlacerPlacementContext extends AutomaticItemPlacementContext {
+		// Shadows the variable facing in the superclass.
+		private final Direction facing;
 		
 		public BlockPlacerPlacementContext(World world, BlockPos pos, Direction facing, ItemStack stack, Direction side) {
 			super(world, pos, facing, stack, side);
+			this.facing = facing;
+		}
+		
+		public Direction getPlayerLookDirection() {
+			return facing.getOpposite();
 		}
 		
 		// SlabBlocks cause a non-funny StackOverflowError

--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/RedstoneInteractionBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/RedstoneInteractionBlock.java
@@ -42,8 +42,8 @@ public class RedstoneInteractionBlock extends Block {
 	public BlockState getPlacementState(ItemPlacementContext ctx) {
 		Direction direction = ctx.getPlayerLookDirection().getOpposite();
 		Direction direction2 = switch (direction) {
-			case DOWN -> ctx.getPlayer().getHorizontalFacing().getOpposite();
-			case UP -> ctx.getPlayer().getHorizontalFacing();
+			case DOWN -> ctx.getHorizontalPlayerFacing().getOpposite();
+			case UP -> ctx.getHorizontalPlayerFacing();
 			case NORTH, SOUTH, WEST, EAST -> Direction.UP;
 		};
 		


### PR DESCRIPTION
Additionally, Block Placers now place blocks relative to the direction they themselves are placed in, as opposed to a static one.

Look direction is opposite to the block placer, as by convention and by implementation in Spectrum, directional blocks face towards the player. This would make the use of a Block Placer moot for things such as dispensers, furnaces, or pistons, as they would always face towards the block that placed them, leaving the face covered.

This technically now also allows for block breakers to be placed further inwards to a tree, allowing for, given some advanced and convoluted redstone, all leaves of a small tree to be broken by a player-simulating block breaker using only Spectrum.