### PR TITLE
Feature: 1.20.1 aria for painters UUID inheritance

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
@@ -133,9 +133,16 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements BlockE
 	}
 	
 	public static final class BlockPlacerPlacementContext extends AutomaticItemPlacementContext {
+		// Shadows the variable facing in the superclass.
+		private final Direction facing;
 		
 		public BlockPlacerPlacementContext(World world, BlockPos pos, Direction facing, ItemStack stack, Direction side) {
 			super(world, pos, facing, stack, side);
+			this.facing = facing;
+		}
+		
+		public Direction getPlayerLookDirection() {
+			return facing.getOpposite();
 		}
 		
 		// SlabBlocks cause a non-funny StackOverflowError

--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
@@ -2,6 +2,7 @@ package de.dafuqs.spectrum.blocks.redstone;
 
 import de.dafuqs.spectrum.*;
 import de.dafuqs.spectrum.compat.claims.*;
+import de.dafuqs.spectrum.registries.*;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.*;
 import net.minecraft.entity.*;
@@ -9,6 +10,7 @@ import net.minecraft.entity.player.*;
 import net.minecraft.item.*;
 import net.minecraft.registry.*;
 import net.minecraft.screen.*;
+import net.minecraft.server.network.*;
 import net.minecraft.server.world.*;
 import net.minecraft.util.*;
 import net.minecraft.util.hit.*;
@@ -51,25 +53,28 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements BlockE
 			world.emitGameEvent(null, GameEvent.BLOCK_ACTIVATE, pos);
 		} else {
 			ItemStack stack = blockEntity.getStack(slot);
-			tryPlace(stack, pointer);
+			PlayerEntity cause = blockEntity.getOwnerIfOnline();
+			tryPlace(stack, pointer, cause);
 		}
 	}
 	
 	// We can't reuse the vanilla BlockPlacementDispenserBehavior, since we are using a different orientation for our block:
 	// BlockPlacerBlock.ORIENTATION instead of DispenserBlock.FACING
-	protected void tryPlace(@NotNull ItemStack stack, BlockPointer pointer) {
+	protected void tryPlace(@NotNull ItemStack stack, BlockPointer pointer, PlayerEntity cause) {
         World world = pointer.getWorld();
         if (stack.getItem() instanceof BlockItem blockItem) {
 			Direction facing = pointer.getBlockState().get(BlockPlacerBlock.ORIENTATION).getFacing();
 			BlockPos placementPos = pointer.getPos().offset(facing);
             Direction placementDirection = world.isAir(placementPos.down()) ? facing : Direction.UP;
 			
-			if (!GenericClaimModsCompat.canPlaceBlock(world, placementPos, null)) {
+			if (!GenericClaimModsCompat.canPlaceBlock(world, placementPos, cause)) {
 				return;
 			}
 			
 			try {
-				blockItem.place(new BlockPlacerPlacementContext(world, placementPos, facing, stack, placementDirection));
+				if(blockItem.place(new BlockPlacerPlacementContext(world, placementPos, facing, stack, placementDirection, cause)).isAccepted()) {
+					if(cause != null && cause.getAbilities().creativeMode) { stack.decrement(1); }
+				}
 				world.syncWorldEvent(WorldEvents.DISPENSER_DISPENSES, pointer.getPos(), 0);
 				world.syncWorldEvent(WorldEvents.DISPENSER_ACTIVATED, pointer.getPos(), pointer.getBlockState().get(BlockPlacerBlock.ORIENTATION).getFacing().getId());
                 world.emitGameEvent(null, GameEvent.BLOCK_PLACE, placementPos);
@@ -81,6 +86,10 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements BlockE
 			world.syncWorldEvent(WorldEvents.DISPENSER_FAILS, pointer.getPos(), 0);
             world.emitGameEvent(null, GameEvent.BLOCK_ACTIVATE, pointer.getPos());
 		}
+	}
+	
+	protected void tryPlace(@NotNull ItemStack itemStack, BlockPointer pointer) {
+		this.tryPlace(itemStack, pointer, null);
 	}
 	
 	@Override
@@ -102,9 +111,12 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements BlockE
 	
 	@Override
 	public void onPlaced(World world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack itemStack) {
-		if (itemStack.hasCustomName()) {
-			if (world.getBlockEntity(pos) instanceof BlockPlacerBlockEntity blockPlacerBlockEntity) {
+		if (world.getBlockEntity(pos) instanceof BlockPlacerBlockEntity blockPlacerBlockEntity) {
+			if (itemStack.hasCustomName()) {
 				blockPlacerBlockEntity.setCustomName(itemStack.getName());
+			}
+			if (placer instanceof ServerPlayerEntity serverPlayerEntity) {
+				blockPlacerBlockEntity.setOwner(serverPlayerEntity);
 			}
 		}
 		
@@ -135,10 +147,22 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements BlockE
 	public static final class BlockPlacerPlacementContext extends AutomaticItemPlacementContext {
 		// Shadows the variable facing in the superclass.
 		private final Direction facing;
+		private final PlayerEntity cause;
 		
-		public BlockPlacerPlacementContext(World world, BlockPos pos, Direction facing, ItemStack stack, Direction side) {
+		public BlockPlacerPlacementContext(World world, BlockPos pos, Direction facing, ItemStack stack, Direction side, PlayerEntity cause) {
 			super(world, pos, facing, stack, side);
 			this.facing = facing;
+			this.cause = cause;
+		}
+		
+		public BlockPlacerPlacementContext(World world, BlockPos pos, Direction facing, ItemStack stack, Direction side) {
+			this(world, pos, facing, stack, side, null);
+		}
+		
+		// Not global, as to avoid any exploits where Ender Droppers et al. can be placed without player consent.
+		@Nullable @Override
+		public PlayerEntity getPlayer() {
+			return this.getStack().isIn(SpectrumItemTags.PLAYER_ATTRIBUTED_PLACEMENT) ? this.cause : null;
 		}
 		
 		public Direction getPlayerLookDirection() {

--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlockEntity.java
@@ -1,15 +1,21 @@
 package de.dafuqs.spectrum.blocks.redstone;
 
+import de.dafuqs.spectrum.api.block.*;
 import de.dafuqs.spectrum.inventories.*;
 import de.dafuqs.spectrum.registries.*;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.*;
 import net.minecraft.entity.player.*;
+import net.minecraft.nbt.*;
 import net.minecraft.screen.*;
 import net.minecraft.text.*;
 import net.minecraft.util.math.*;
 
-public class BlockPlacerBlockEntity extends DispenserBlockEntity {
+import java.util.*;
+
+public class BlockPlacerBlockEntity extends DispenserBlockEntity implements PlayerOwned {
+	
+	private UUID ownerUUID;
 	
 	public BlockPlacerBlockEntity(BlockPos pos, BlockState state) {
 		super(SpectrumBlockEntities.BLOCK_PLACER, pos, state);
@@ -25,4 +31,26 @@ public class BlockPlacerBlockEntity extends DispenserBlockEntity {
 		return Spectrum3x3ContainerScreenHandler.createTier1(syncId, playerInventory, this);
 	}
 	
+	@Override
+	public UUID getOwnerUUID() {
+		return this.ownerUUID;
+	}
+	
+	@Override
+	public void setOwner(PlayerEntity playerEntity) {
+		this.ownerUUID = playerEntity.getUuid();
+		this.markDirty();
+	}
+	
+	@Override
+	public void writeNbt(NbtCompound nbt) {
+		super.writeNbt(nbt);
+		PlayerOwned.writeOwnerUUID(nbt, this.ownerUUID);
+	}
+	
+	@Override
+	public void readNbt(NbtCompound nbt) {
+		super.readNbt(nbt);
+		this.ownerUUID = PlayerOwned.readOwnerUUID(nbt);
+	}
 }

--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/RedstoneInteractionBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/RedstoneInteractionBlock.java
@@ -42,8 +42,8 @@ public class RedstoneInteractionBlock extends Block {
 	public BlockState getPlacementState(ItemPlacementContext ctx) {
 		Direction direction = ctx.getPlayerLookDirection().getOpposite();
 		Direction direction2 = switch (direction) {
-			case DOWN -> ctx.getPlayer().getHorizontalFacing().getOpposite();
-			case UP -> ctx.getPlayer().getHorizontalFacing();
+			case DOWN -> ctx.getHorizontalPlayerFacing().getOpposite();
+			case UP -> ctx.getHorizontalPlayerFacing();
 			case NORTH, SOUTH, WEST, EAST -> Direction.UP;
 		};
 		

--- a/src/main/java/de/dafuqs/spectrum/registries/SpectrumItemTags.java
+++ b/src/main/java/de/dafuqs/spectrum/registries/SpectrumItemTags.java
@@ -31,6 +31,7 @@ public class SpectrumItemTags {
 	public static final TagKey<Item> PASTEL_NODE_UPGRADES = of("pastel_node_upgrades");
 	public static final TagKey<Item> TAG_FILTERING_ITEMS = of("tag_filtering_items");
 	public static final TagKey<Item> WEEPING_GALA_LOGS = of("weeping_gala_logs");
+	public static final TagKey<Item> PLAYER_ATTRIBUTED_PLACEMENT = of("player_attributed_placement");
 
 	private static TagKey<Item> of(String id) {
 		return TagKey.of(RegistryKeys.ITEM, SpectrumCommon.locate(id));

--- a/src/main/resources/data/spectrum/tags/items/player_attributed_placement.json
+++ b/src/main/resources/data/spectrum/tags/items/player_attributed_placement.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "spectrum:block_breaker",
+		"spectrum:block_placer"
+	]
+}


### PR DESCRIPTION
**Includes the bugfix also, so probably merge after the bugfix is, if necessary**


Block Placers now remember the player that placed them, and an item tag is added for BlockItems that should be placed as the player that placed the Placer - only the Placer and Breaker are in this tag by default. This means Breakers placed by Placers can break blocks the player that placed the Placer can break.