### PR TITLE
New year new minor fixes

### DIFF
--- a/src/main/resources/assets/spectrum/models/block/paltaeria_fragment_block.json
+++ b/src/main/resources/assets/spectrum/models/block/paltaeria_fragment_block.json
@@ -8,5 +8,12 @@
     "west": "spectrum:block/paltaeria_fragment_block_side",
     "up": "spectrum:block/paltaeria_fragment_block_vertical",
     "down": "spectrum:block/paltaeria_fragment_block_vertical"
-  }
+  },
+	"display": {
+		"ground": {
+			"rotation": [0, 0, -180],
+			"translation": [0, -4.5, 0],
+			"scale": [0.25, 0.25, 0.25]
+		}
+	}
 }

--- a/src/main/resources/assets/spectrum/models/block/paltaeria_ore.json
+++ b/src/main/resources/assets/spectrum/models/block/paltaeria_ore.json
@@ -2,5 +2,12 @@
   "parent": "minecraft:block/cube_all",
   "textures": {
     "all": "spectrum:block/paltaeria_ore"
-  }
+  },
+	"display": {
+		"ground": {
+			"rotation": [0, 0, -180],
+			"translation": [0, -4.5, 0],
+			"scale": [0.25, 0.25, 0.25]
+		}
+	}
 }

--- a/src/main/resources/assets/spectrum/models/item/dreamflayer.json
+++ b/src/main/resources/assets/spectrum/models/item/dreamflayer.json
@@ -4,26 +4,18 @@
     "layer0": "spectrum:item/dreamflayer"
   },
   "overrides": [
+
+		{
+			"predicate": {
+				"activated": 1.0
+			},
+			"model": "spectrum:item/dreamflayer_activated"
+		},
     {
       "predicate": {
-        "oversized": 0.0,
-        "activated": 1.0
-      },
-      "model": "spectrum:item/dreamflayer_activated"
-    },
-    {
-      "predicate": {
-        "oversized": 1.0,
-        "activated": 0.0
-      },
-      "model": "spectrum:item/dreamflayer_oversized"
-    },
-    {
-      "predicate": {
-        "activated": 1.0,
         "oversized": 1.0
       },
-      "model": "spectrum:item/dreamflayer_activated_oversized"
+      "model": "spectrum:item/dreamflayer_oversized"
     }
   ]
 }

--- a/src/main/resources/assets/spectrum/models/item/dreamflayer_activated.json
+++ b/src/main/resources/assets/spectrum/models/item/dreamflayer_activated.json
@@ -2,5 +2,13 @@
   "parent": "spectrum:item/handheld_oversized",
   "textures": {
     "layer0": "spectrum:item/dreamflayer_activated"
-  }
+  },
+  "overrides": [
+    {
+			"predicate": {
+				"activated": 1.0
+			},
+			"model": "spectrum:item/dreamflayer_activated_oversized"
+		}
+  ]
 }

--- a/src/main/resources/assets/spectrum/models/item/paltaeria_gem.json
+++ b/src/main/resources/assets/spectrum/models/item/paltaeria_gem.json
@@ -1,6 +1,15 @@
 {
-  "parent": "minecraft:item/generated",
-  "textures": {
-    "layer0": "spectrum:item/paltaeria_gem"
-  }
+	"format_version": "1.21.11",
+	"credit": "Made with Blockbench",
+	"parent": "minecraft:item/generated",
+	"textures": {
+		"layer0": "spectrum:item/paltaeria_gem"
+	},
+	"display": {
+		"ground": {
+			"rotation": [0, 0, 180],
+			"translation": [0, -4.5, 0],
+			"scale": [0.5, 0.5, 0.5]
+		}
+	}
 }


### PR DESCRIPTION
Summary:

- Fixed mistake on not having structure voids in `bottom4` changes to the undergrowth manor (foxes are still vanishing for some reason even though I went the extra mile to clean them up with the effect duplicates being removed) (you'd think using /place template would place the template with the structure voids huh?)

- Fix a missed broken recipe for making memories of pillagers (daf missed swaping a `tag` paramiter to a `item` one

- Adjusted Palaetia ore, gem, and floatblocks to render upside-down to better compliment their properties and fix visibility issues

- Fixed Dreamflayers Oversized render not appearing when in the active state. Recomend moving forwarwd to have the `oversized` predicate check for a model override be done within the file that the main item model is overriding to (see commit for clarification; thanks mojank :/ )