### PR TITLE
fix trigger halos not un-triggering for passive sources or sinks

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/network/PastelTransmissionLogic.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/network/PastelTransmissionLogic.java
@@ -153,14 +153,8 @@ public class PastelTransmissionLogic {
 					this.network.addTransmission(transmission, travelTime);
 					SpectrumS2CPacketSender.sendPastelTransmissionParticle(this.network, travelTime, transmission);
 					
-					if (transferMode == TransferMode.PULL) {
-						destinationNode.markTransferred();
-					} else if (transferMode == TransferMode.PUSH) {
-						sourceNode.markTransferred();
-					} else {
-						destinationNode.markTransferred();
-						sourceNode.markTransferred();
-					}
+					destinationNode.markTransferred(transferMode != TransferMode.PUSH);
+					sourceNode.markTransferred(transferMode != TransferMode.PULL);
 					
 					destinationNode.addItemCountUnderway(transferrableAmount);
 					transaction.commit();

--- a/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlockEntity.java
@@ -327,7 +327,11 @@ public class PastelNodeBlockEntity extends BlockEntity implements FilterConfigur
 
 		return canTransfer && notPowered;
 	}
-
+	
+	public void markTransferred() {
+		markTransferred(true);
+	}
+	
 	public void markTransferred(boolean setTransferCooldown) {
 		if (triggerTransfer) { markTriggered(); }
 		if (setTransferCooldown && world != null) { this.lastTransferTick = world.getTime(); }

--- a/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/pastel_network/nodes/PastelNodeBlockEntity.java
@@ -328,13 +328,10 @@ public class PastelNodeBlockEntity extends BlockEntity implements FilterConfigur
 		return canTransfer && notPowered;
 	}
 
-	public void markTransferred() {
-		if (triggerTransfer) {
-			markTriggered();
-		}
-
-		this.lastTransferTick = world.getTime();
-		this.markDirty();
+	public void markTransferred(boolean setTransferCooldown) {
+		if (triggerTransfer) { markTriggered(); }
+		if (setTransferCooldown && world != null) { this.lastTransferTick = world.getTime(); }
+		if (triggerTransfer || setTransferCooldown) { this.markDirty(); }
 	}
 
 	@Override


### PR DESCRIPTION
Apologies for the late upload, this was originally going to be more than just one fix, but then I found out *why* the other fixes weren't fixed yet - as they quite complicated. Will continue trying.

Trigger halos currently don't 'unset' unless they transfer _actively_ to or from the current node to a passive node. It will work for gather nodes when pulling from a provider, but doesn't work for a provider node being pulled _from_ from a gather node node. Essentially, it wouldn't unset if the node doesn't incur a transfer cooldown.