### PR TITLE
Fix Rock Candy for Connector

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/rock_candy/SugarStickBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/rock_candy/SugarStickBlock.java
@@ -1,5 +1,6 @@
 package de.dafuqs.spectrum.blocks.rock_candy;
 
+import de.dafuqs.spectrum.*;
 import de.dafuqs.spectrum.blocks.*;
 import de.dafuqs.spectrum.helpers.ColorHelper;
 import de.dafuqs.spectrum.particle.effect.*;
@@ -108,9 +109,17 @@ public class SugarStickBlock extends Block implements RockCandy {
 				List<ItemEntity> itemEntities = world.getNonSpectatingEntities(ItemEntity.class, Box.of(Vec3d.ofCenter(pos), ITEM_SEARCH_RANGE, ITEM_SEARCH_RANGE, ITEM_SEARCH_RANGE));
 				Collections.shuffle(itemEntities);
 				for (ItemEntity itemEntity : itemEntities) {
-					// is the item also submerged?
-					// lazy, but mostly accurate and performant way to check if it's the same liquid pool
-					if (!itemEntity.isSubmergedIn(SpectrumFluidTags.LIQUID_CRYSTAL)) {
+					
+					// This implements checking if the item is submerged at eye level. This is necessary as the mixin went haywire
+					// in a connector environment (TLDR: isSubmergedIn() breaks though mixin transmog with Connector, this fixes it
+					var currentFluidHeight = itemEntity.getBlockStateAtPos().getFluidState().getHeight();
+					var eyePosY = itemEntity.getEyePos().y;
+					var entityPosFloorY = Math.floor(itemEntity.getEyePos().y);
+					var entityEyeFloorOffset = eyePosY -  entityPosFloorY;
+					
+					// Checks to see if the checked item is submerged and in liquid crystal, if one of these are false (making this true), continue to next to aiterate.
+					// This is to replace the submerge mixin check, given connector was screwing with its check
+					if (!itemEntity.getBlockStateAtPos().isOf(SpectrumBlocks.LIQUID_CRYSTAL)|| entityEyeFloorOffset > currentFluidHeight) {
 						continue;
 					}
 					

--- a/src/main/java/de/dafuqs/spectrum/mixin/EntityApplyFluidsMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/EntityApplyFluidsMixin.java
@@ -29,7 +29,7 @@ public abstract class EntityApplyFluidsMixin implements TouchingWaterAware {
 	@Override
 	public void spectrum$setActuallyTouchingWater(boolean actuallyTouchingWater) { this.actuallyTouchingWater = actuallyTouchingWater; }
 	
-	@Deprecated //Mixin breaks in Connector Environment -Shibva
+	//This breaks in a connector enviorment for some reason. -Shibva
 	//@Inject(method = "isSubmergedIn", at = @At("RETURN"), cancellable = true)
 	//public void spectrum$isSubmergedIn(TagKey<Fluid> fluidTag, CallbackInfoReturnable<Boolean> cir) {
 	//	if (!cir.getReturnValue() && fluidTag == FluidTags.WATER) {

--- a/src/main/java/de/dafuqs/spectrum/mixin/EntityApplyFluidsMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/EntityApplyFluidsMixin.java
@@ -29,12 +29,13 @@ public abstract class EntityApplyFluidsMixin implements TouchingWaterAware {
 	@Override
 	public void spectrum$setActuallyTouchingWater(boolean actuallyTouchingWater) { this.actuallyTouchingWater = actuallyTouchingWater; }
 	
-	@Inject(method = "isSubmergedIn", at = @At("RETURN"), cancellable = true)
-	public void spectrum$isSubmergedIn(TagKey<Fluid> fluidTag, CallbackInfoReturnable<Boolean> cir) {
-		if (!cir.getReturnValue() && fluidTag == FluidTags.WATER) {
-			cir.setReturnValue(this.submergedFluidTag.contains(SpectrumFluidTags.SWIMMABLE_FLUID));
-		}
-	}
+	@Deprecated //Mixin breaks in Connector Environment -Shibva
+	//@Inject(method = "isSubmergedIn", at = @At("RETURN"), cancellable = true)
+	//public void spectrum$isSubmergedIn(TagKey<Fluid> fluidTag, CallbackInfoReturnable<Boolean> cir) {
+	//	if (!cir.getReturnValue() && fluidTag == FluidTags.WATER) {
+	//		cir.setReturnValue(this.submergedFluidTag.contains(SpectrumFluidTags.SWIMMABLE_FLUID));
+	//	}
+	//}
 	
 	@Inject(method = "isSubmergedInWater", at = @At("RETURN"), cancellable = true)
 	public void spectrum$isSubmergedInWater(CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/resources/data/spectrum/weapon_attributes/draconic_twinsword.json
+++ b/src/main/resources/data/spectrum/weapon_attributes/draconic_twinsword.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bettercombat:twin_blade"
+}

--- a/src/main/resources/data/spectrum/weapon_attributes/dragon_talon.json
+++ b/src/main/resources/data/spectrum/weapon_attributes/dragon_talon.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bettercombat:dagger"
+}

--- a/src/main/resources/data/spectrum/weapon_attributes/knotted_sword.json
+++ b/src/main/resources/data/spectrum/weapon_attributes/knotted_sword.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bettercombat:sword"
+}

--- a/src/main/resources/data/spectrum/weapon_attributes/nectar_lance.json
+++ b/src/main/resources/data/spectrum/weapon_attributes/nectar_lance.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bettercombat:sword"
+}


### PR DESCRIPTION
Issue was caused by mixin not doing well with connector transmog; this fix redoes the method to check for it while still allowing for the same end-goal and handling to be accounted for

- commented out submersion check, it was the only one using it; remove if you think its nessisary to purge

- Implitmented Connector-fiendly check, taking advantage of fluid block height being a thing. This should work the same as before while preventing situations like it being on a fence from causing problems (Thanks @800020h for pointing it out)

might not be the most performant, but I dont see it as a problem if its not ticking constantly; **any further impovements made should be checked to make sure it works with connector, otherwise this entire thing was pointless**


Sidenote: Give me a rundown how to sync stuff with changes, I had to wipe my workspace becasue I had old commits that were already pushed, AUGH