### PR TITLE
Make crystal apothecary behave better with mixed budding types

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/energy/CrystalApothecaryBlockEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/energy/CrystalApothecaryBlockEntity.java
@@ -93,6 +93,9 @@ public class CrystalApothecaryBlockEntity extends LootableContainerBlockEntity i
 			}
 		}
 		
+		List<ItemStack> needsAwarding = new ArrayList<>();
+		int totalNeedsAwarding = 0;
+		
 		// for each of those blocks generate some loot
 		double gameRuleTickModifier = world.getGameRules().get(GameRules.RANDOM_TICK_SPEED).get() / 3.0;
 		for (Map.Entry<Block, Integer> match : matches.entrySet()) {
@@ -103,10 +106,56 @@ public class CrystalApothecaryBlockEntity extends LootableContainerBlockEntity i
 			if (compensatedItemCount > 0) {
 				ItemStack compensatedStack = drop.compensatedStack().copy();
 				compensatedStack.setCount(compensatedItemCount);
-				
-				ItemStack remainingStack = InventoryHelper.smartAddToInventory(compensatedStack, blockEntity, null);
-				if (!remainingStack.isEmpty()) {
-					break; // overflow will be voided
+				needsAwarding.add(compensatedStack);
+				totalNeedsAwarding += compensatedItemCount;
+			}
+		}
+		
+		if (needsAwarding.size() <= 1) {
+			for (ItemStack awardStack : needsAwarding) {
+				InventoryHelper.smartAddToInventory(awardStack, blockEntity, null);
+			}
+			return;
+		}
+		
+		for (int slot = 0; slot < blockEntity.size(); slot++) {
+			if (totalNeedsAwarding <= 0) {
+				break;
+			}
+			ItemStack currentStack = blockEntity.getStack(slot);
+			if (currentStack.isEmpty()) {
+				int selector = world.random.nextInt(totalNeedsAwarding);
+				int acc = 0;
+				for (ItemStack awardStack : needsAwarding) {
+					acc += awardStack.getCount();
+					if (selector < acc) {
+						int maxCount = Math.min(blockEntity.getMaxCountPerStack(), awardStack.getMaxCount());
+						int toAward = Math.min(maxCount, awardStack.getCount());
+						ItemStack newStack = awardStack.copy();
+						newStack.setCount(toAward);
+						awardStack.decrement(toAward);
+						blockEntity.setStack(slot, newStack);
+						totalNeedsAwarding -= toAward;
+						break;
+					}
+				}
+			} else {
+				int maxCount = Math.min(blockEntity.getMaxCountPerStack(), currentStack.getMaxCount());
+				if (currentStack.getCount() > maxCount) {
+					continue;
+				}
+				int wantsAdded = maxCount - currentStack.getCount();
+				for (ItemStack awardStack : needsAwarding) {
+					if (wantsAdded <= 0) {
+						break;
+					}
+					if (ItemStack.canCombine(currentStack, awardStack)) {
+						int canAdd = Math.min(wantsAdded, awardStack.getCount());
+						awardStack.decrement(canAdd);
+						currentStack.increment(canAdd);
+						totalNeedsAwarding -= canAdd;
+						wantsAdded -= canAdd;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
this PR rewrites the insertion part of the compensation algorithm to insert the compensation reward stacks slot-by-slot weighted-randomly, which results in mixed budding types having (roughly) correct distribution instead of hashes-first-gets-all. while this does make the algorithm more complex and probably slower, it probably doesn't matter as this isn't a very hot code path.

because, well, this is what happens currently if you let crystal apothecary's compensation run for a sufficiently long time with mixed types of budding:
<img width="332" height="500" alt="image" src="https://github.com/user-attachments/assets/ba663d37-701a-4079-bce0-36204f366857" />