### PR TITLE
Respect the result of Item#finishUsingItem in Omni Accelerator Item Projectile Behaviours

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/api/interaction/ItemProjectileBehavior.java
+++ b/src/main/java/de/dafuqs/spectrum/api/interaction/ItemProjectileBehavior.java
@@ -128,7 +128,7 @@ public interface ItemProjectileBehavior {
 				}
 				
 				// Force-feeds food, applies potions, ...
-				stack.getItem().finishUsingItem(stack, livingTarget.level(), livingTarget);
+				return stack.getItem().finishUsingItem(stack, livingTarget.level(), livingTarget);
 			}
 			return stack;
 		}


### PR DESCRIPTION
fixes some cases where hitting an entity with an item from the accelerator could cause the item to not get consumed/not update properly