### PR TITLE
Update the life stage of upper vines in onRemove instead of destroy

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/deeper_down/flora/TriStateVineBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/deeper_down/flora/TriStateVineBlock.java
@@ -144,17 +144,20 @@ public abstract class TriStateVineBlock extends BushBlock implements Bonemealabl
 
         return count;
     }
-
-    @Override
-	public void destroy(LevelAccessor world, BlockPos pos, BlockState state) {
-		var roof = BlockReference.of(world, pos.above());
-
-        if (roof.isOf(this)) {
-			roof.setProperty(LIFE_STAGE, getLowestLifeStage(world, pos.below(), state.getValue(LIFE_STAGE)));
-            roof.update(world);
-        }
-
-        scheduleBreakCheck(world, pos);
+	
+	@Override
+	protected void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+		if (!state.is(newState.getBlock())) {
+			var roof = BlockReference.of(level, pos.above());
+			
+			if (roof.isOf(this)) {
+				roof.setProperty(LIFE_STAGE, getLowestLifeStage(level, pos.below(), state.getValue(LIFE_STAGE)));
+				roof.update(level);
+			}
+			
+			scheduleBreakCheck(level, pos);
+		}
+		super.onRemove(state, level, pos, newState, movedByPiston);
     }
 	
 	public LifeStage getLowestLifeStage(LevelAccessor world, BlockPos pos, LifeStage stage) {


### PR DESCRIPTION
fixes non-player block breaking locking TriStateVineBlock-based blocks into the mature stage