### PR TITLE
Fix entity submersion checks for Spectrum fluids + a thing

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/mixin/compat/connectormod/present/EntityAnnoyingForgeQuirkMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/compat/connectormod/present/EntityAnnoyingForgeQuirkMixin.java
@@ -1,0 +1,24 @@
+package de.dafuqs.spectrum.mixin.compat.connectormod.present;
+
+import com.llamalad7.mixinextras.sugar.*;
+import net.minecraft.entity.*;
+import net.minecraft.fluid.*;
+import net.minecraft.registry.tag.*;
+import org.objectweb.asm.*;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.*;
+
+import java.util.*;
+
+@Mixin(Entity.class)
+public class EntityAnnoyingForgeQuirkMixin {
+	@Shadow
+	@Final
+	private Set<TagKey<Fluid>> submergedFluidTag;
+	
+	@Inject(method = "updateSubmergedInWaterState", at = @At(value = "FIELD", target = "forgeFluidTypeOnEyes", opcode = Opcodes.PUTFIELD, remap = false))
+	public void spectrum$actuallyUpdateSubmergedInWaterStateOnStupidForge(CallbackInfo ci, @Local FluidState fluidState) {
+		fluidState.streamTags().forEach(this.submergedFluidTag::add);
+	}
+}

--- a/src/main/resources/data/spectrum/weapon_attributes/draconic_twinsword.json
+++ b/src/main/resources/data/spectrum/weapon_attributes/draconic_twinsword.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bettercombat:twin_blade"
+}

--- a/src/main/resources/data/spectrum/weapon_attributes/dragon_talon.json
+++ b/src/main/resources/data/spectrum/weapon_attributes/dragon_talon.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bettercombat:dagger"
+}

--- a/src/main/resources/data/spectrum/weapon_attributes/knotted_sword.json
+++ b/src/main/resources/data/spectrum/weapon_attributes/knotted_sword.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bettercombat:sword"
+}

--- a/src/main/resources/data/spectrum/weapon_attributes/nectar_lance.json
+++ b/src/main/resources/data/spectrum/weapon_attributes/nectar_lance.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bettercombat:sword"
+}

--- a/src/main/resources/spectrum.mixins.json
+++ b/src/main/resources/spectrum.mixins.json
@@ -104,8 +104,9 @@
     "compat.connectormod.absent.EntityApplyFluidsMixinNoSinytra",
     "compat.connectormod.absent.ExplosionMixin",
     "compat.connectormod.absent.PlayerEntityMixin",
+    "compat.connectormod.present.EntityAnnoyingForgeQuirkMixin",
     "compat.connectormod.present.ExplosionMixin",
-		"compat.kubejs.absent.RecipeManagerMixin",
+    "compat.kubejs.absent.RecipeManagerMixin",
     "compat.quilt_status_effect.absent.LivingEntityPreventStatusClearMixin",
     "compat.quilt_status_effect.present.SpectrumEventListenersMixin"
   ],


### PR DESCRIPTION
(also relevant for 1.21, with `updateFluidOnEyes` as the new inject target name)

Additionally pulls an unrelated fix from #804 by @Shibva as it would be otherwise unmerged if this one is merged.