### PR TITLE
[1.20.1 Fabric] Fix client world random state corruption when rendering Jade Vine Roots and Shooting Stars.

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/jade_vines/JadeVineRootsBlockEntityRenderer.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/jade_vines/JadeVineRootsBlockEntityRenderer.java
@@ -7,10 +7,12 @@ import net.minecraft.client.render.*;
 import net.minecraft.client.render.block.*;
 import net.minecraft.client.render.block.entity.*;
 import net.minecraft.client.util.math.*;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.World;
 
 @Environment(EnvType.CLIENT)
 public class JadeVineRootsBlockEntityRenderer implements BlockEntityRenderer<JadeVineRootsBlockEntity> {
+	private final Random random = Random.create();
 	
 	public JadeVineRootsBlockEntityRenderer(BlockEntityRendererFactory.Context ctx) {
 	
@@ -32,7 +34,7 @@ public class JadeVineRootsBlockEntityRenderer implements BlockEntityRenderer<Jad
 						matrixStack,
 						vertexConsumerProvider.getBuffer(RenderLayers.getMovingBlockLayer(fenceBlockState)),
 						true,
-						world.random,
+						random,
 						fenceBlockState.getRenderingSeed(entity.getPos()),
 						OverlayTexture.DEFAULT_UV
 				);

--- a/src/main/java/de/dafuqs/spectrum/entity/render/ShootingStarEntityRenderer.java
+++ b/src/main/java/de/dafuqs/spectrum/entity/render/ShootingStarEntityRenderer.java
@@ -11,10 +11,12 @@ import net.minecraft.client.util.math.*;
 import net.minecraft.screen.*;
 import net.minecraft.util.*;
 import net.minecraft.util.math.*;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.*;
 
 @Environment(EnvType.CLIENT)
 public class ShootingStarEntityRenderer extends EntityRenderer<ShootingStarEntity> {
+	private final Random random = Random.create();
 	
 	public ShootingStarEntityRenderer(EntityRendererFactory.Context context) {
 		super(context);
@@ -35,7 +37,7 @@ public class ShootingStarEntityRenderer extends EntityRenderer<ShootingStarEntit
 				BlockPos blockpos = BlockPos.ofFloored(shootingStarEntity.getX(), shootingStarEntity.getBoundingBox().maxY, shootingStarEntity.getZ());
 				matrixStack.translate(-0.5, 0.0, -0.5);
 				BlockRenderManager blockRenderManager = MinecraftClient.getInstance().getBlockRenderManager();
-				blockRenderManager.getModelRenderer().render(world, blockRenderManager.getModel(blockState), blockState, blockpos, matrixStack, vertexConsumerProvider.getBuffer(RenderLayers.getMovingBlockLayer(blockState)), false, world.random, blockState.getRenderingSeed(shootingStarEntity.getBlockPos()), OverlayTexture.DEFAULT_UV);
+				blockRenderManager.getModelRenderer().render(world, blockRenderManager.getModel(blockState), blockState, blockpos, matrixStack, vertexConsumerProvider.getBuffer(RenderLayers.getMovingBlockLayer(blockState)), false, random, blockState.getRenderingSeed(shootingStarEntity.getBlockPos()), OverlayTexture.DEFAULT_UV);
 				matrixStack.pop();
 				super.render(shootingStarEntity, yaw, tickDelta, matrixStack, vertexConsumerProvider, light);
 			}


### PR DESCRIPTION
<img src="https://files.y2k.diy/av/circle/kryn.webp" width="40" height="40" align="center"> <b>Kryn</b> commented:

We forgot a patch while upstreaming fixes from our modpack.

Jade Vine Roots and Shooting Stars both pass the shared client world random to the block model renderer, which immediately reinitializes it with the blockstate's "rendering seed". This results in particle effects and other randomized client-side phenomena becoming predictable — usually, torches shoot out continuous jets of smoke with no fire, particle rain starts falling in perfect columns, some particle effects stop spawning at all. It even affects the particle effects of the Jade Vine itself.

As such, it is incorrect to pass a random instance to the block model renderer that is not dedicated to the purpose of rendering block models. Unfortunately, the Random instance used by vanilla for this purpose is held in a private field. It is less work and more maintainable to simply use a per-renderer Random instance rather than using an Accessor.

Changes made by hand in a text editor — we confirmed the mod still compiles and runs.
