### PR TITLE
[1.21.1 NeoForge] Fix client world random state corruption when rendering Jade Vine Roots.

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/jade_vines/JadeVineRootsBlockEntityRenderer.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/jade_vines/JadeVineRootsBlockEntityRenderer.java
@@ -6,12 +6,14 @@ import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.block.*;
 import net.minecraft.client.renderer.blockentity.*;
 import net.minecraft.client.renderer.texture.*;
+import net.minecraft.util.*;
 import net.minecraft.world.level.*;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.*;
 
 
 public class JadeVineRootsBlockEntityRenderer implements BlockEntityRenderer<JadeVineRootsBlockEntity> {
+	private final RandomSource random = RandomSource.create();
 	
 	@SuppressWarnings("unused")
 	public JadeVineRootsBlockEntityRenderer(BlockEntityRendererProvider.Context ctx) {
@@ -33,7 +35,7 @@ public class JadeVineRootsBlockEntityRenderer implements BlockEntityRenderer<Jad
 						poseStack,
 						vertexConsumerProvider.getBuffer(ItemBlockRenderTypes.getMovingBlockRenderType(fenceBlockState)),
 						true,
-						world.random,
+						random,
 						fenceBlockState.getSeed(entity.getBlockPos()),
 						OverlayTexture.NO_OVERLAY
 				);


### PR DESCRIPTION
<img src="https://files.y2k.diy/av/circle/kryn.webp" width="40" height="40" align="center"> <b>Kryn</b> commented:

We forgot a patch while upstreaming fixes from our modpack.

Jade Vine Roots passes the shared client world random to the block model renderer, which immediately reinitializes it with the blockstate's "rendering seed". This results in particle effects and other randomized client-side phenomena becoming predictable — usually, torches shoot out continuous jets of smoke with no fire, particle rain starts falling in perfect columns, some particle effects stop spawning at all. It even affects the particle effects of the Jade Vine itself.

As such, it is incorrect to pass a random instance to the block model renderer that is not dedicated to the purpose of rendering block models. Unfortunately, the Random instance used by vanilla for this purpose is held in a private field. It is less work and more maintainable to simply use a per-renderer Random instance rather than using an Accessor.

The rendering of Shooting Stars was rewritten in the NeoForge port, so they're not affected.

Changes made by hand in a text editor — we confirmed the mod still compiles and runs.
