### PR TITLE
What do you mean its opaque, ITS GLASS!!!

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/fusion_shrine/FusionShrineBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fusion_shrine/FusionShrineBlock.java
@@ -63,12 +63,16 @@ public class FusionShrineBlock extends InWorldInteractionBlock {
 		// getTopY() returns the topmost "air" block
 		// which may or may not be the pos of the Fusion Shrine
 		// we search down until we find the shrine itself or a non-opaque block
+		
+		// New tag check: any block that is in the c:glass_blocks tag will be seen as valid REGARDLESS OF OPAQUENESS (this is due to colored glass and tinted glass being opaque)
+		//  Should be stable since it's a using common tag.  ~Shibva was here, 2026
+		
 		int topY = world.getTopY(Heightmap.Type.WORLD_SURFACE, shrinePos.getX(), shrinePos.getZ());
 		BlockPos.Mutable mutablePos = new BlockPos.Mutable(shrinePos.getX(), topY, shrinePos.getZ());
 		for (int y = topY; y > shrinePos.getY(); y--) {
 			mutablePos.setY(y - 1);
 			BlockState posState = world.getBlockState(mutablePos);
-			if (posState.getOpacity(world, mutablePos) > 0) {
+			if (posState.getOpacity(world, mutablePos) > 0 || ( posState.getOpacity(world, mutablePos) > 0 && !SpectrumBlockTags.isIn(SpectrumBlockTags.GLASS_BLOCKS, posState.getBlock())) ) {
 				break;
 			}
 		}

--- a/src/main/java/de/dafuqs/spectrum/registries/SpectrumBlockTags.java
+++ b/src/main/java/de/dafuqs/spectrum/registries/SpectrumBlockTags.java
@@ -2,9 +2,13 @@ package de.dafuqs.spectrum.registries;
 
 import de.dafuqs.spectrum.*;
 import net.minecraft.block.*;
+import net.minecraft.block.*;
 import net.minecraft.registry.*;
+import net.minecraft.registry.entry.*;
 import net.minecraft.registry.tag.*;
 import net.minecraft.util.*;
+
+import java.util.*;
 
 public class SpectrumBlockTags {
 	
@@ -78,7 +82,7 @@ public class SpectrumBlockTags {
 	
 	// COMMON TAGS ("c" namespace)
 	public static final TagKey<Block> LIGHTNING_RODS = common("lightning_rods");
-	
+	public static final TagKey<Block> GLASS_BLOCKS = common("glass_blocks");
 	
 	private static TagKey<Block> of(String id) {
 		return TagKey.of(RegistryKeys.BLOCK, SpectrumCommon.locate(id));
@@ -87,5 +91,14 @@ public class SpectrumBlockTags {
 	private static TagKey<Block> common(String id) {
 		return TagKey.of(RegistryKeys.BLOCK, new Identifier("c", id));
 	}
-
+	
+	
+	public static boolean isIn(TagKey<Block> tag, Block block) {
+		Optional<RegistryKey<Block>> optionalKey = Registries.BLOCK.getKey(block);
+		if (optionalKey.isEmpty()) {
+			return false;
+		}
+		Optional<RegistryEntry.Reference<Block>> registryEntry = Registries.BLOCK.getEntry(optionalKey.get());
+		return registryEntry.filter(blockReference -> Registries.BLOCK.getOrCreateEntryList(tag).contains(blockReference)).isPresent();
+	}
 }


### PR DESCRIPTION
- added registry reference for `c:glass_blocks` (common registry) to SpectrumBlockTags

- modified how `FusionShrineBlock` checks for sky obstructions; it will now let any block under `c:glass_blocks` as a valid block REGARDLESS of if its opaque level. This is due to tinted and colored glass returning an opaque value of 15, even though YOU CAN SEE THOUGH IT. This also expands on other glass blocks that can be compatible with any shrine-related builds.
  **This should fix issues with colored and tinted glass blocks by default**
  - Ender glass working is unlikely if it wasn't working already, and is gonna stay that way unless there's a high demand for it, which in that case will require a special check for it.

- TODO: implement in 21.1 fabric and Neo (use `forge:glass` instead)

Tested-by: Shibva <38770780+shibva@users.noreply.github.com>