### PR TITLE
[1.20.1] add surveillance maps

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/registries/SpectrumStructureTags.java
+++ b/src/main/java/de/dafuqs/spectrum/registries/SpectrumStructureTags.java
@@ -13,6 +13,7 @@ import java.util.*;
 public class SpectrumStructureTags {
 	
 	public static final TagKey<Structure> MYSTERIOUS_COMPASS_LOCATED = of("mysterious_compass_located");
+	public static final TagKey<Structure> ON_SURVEILLANCE_MAPS = of("on_surveillance_maps");
 	public static final TagKey<Structure> UNLOCATABLE = of("unlocatable");
 	
 	private static TagKey<Structure> of(String id) {

--- a/src/main/resources/assets/spectrum/lang/en_us.json
+++ b/src/main/resources/assets/spectrum/lang/en_us.json
@@ -5777,6 +5777,8 @@
   "lore.spectrum.time_travel_tap": "Worthy of a Time Traveller",
   "lore.spectrum.evernectar": "...Evernectar?",
 
+  "spectrum.filled_map.undergrowth_manor_surveillance": "Surveillance Map",
+
   "______food_tooltips": "Food Tooltips:",
   "spectrum.food.withChance": "%s [%d%%]",
   "spectrum.food.whenEaten": "When Eaten:",

--- a/src/main/resources/data/spectrum/loot_tables/chests/city_below/seed_vault_side_room.json
+++ b/src/main/resources/data/spectrum/loot_tables/chests/city_below/seed_vault_side_room.json
@@ -2,26 +2,38 @@
   "type": "minecraft:chest",
   "pools": [
     {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:map",
+          "functions": [
+            {
+              "function": "minecraft:exploration_map",
+              "destination": "spectrum:on_surveillance_maps",
+              "decoration": "minecraft:target_point",
+              "search_radius": 50,
+              "skip_existing_chunks": false,
+              "zoom": 2
+            },
+            {
+              "function": "minecraft:set_name",
+              "target": "item_name",
+              "name": {
+                "translate": "spectrum.filled_map.undergrowth_manor_surveillance"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "rolls": {
         "min": 2,
         "max": 3
       },
       "bonus_rolls": 0,
       "entries": [
-        {
-          "type": "minecraft:item",
-          "name": "spectrum:vegetal",
-          "weight": 3,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 3,
-                "max": 6
-              }
-            }
-          ]
-        },
         {
           "type": "minecraft:item",
           "name": "minecraft:bucket",

--- a/src/main/resources/data/spectrum/tags/worldgen/structure/on_surveillance_maps.json
+++ b/src/main/resources/data/spectrum/tags/worldgen/structure/on_surveillance_maps.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "#spectrum:lizard_dens",
     "spectrum:undergrowth_manor"
   ]
 }

--- a/src/main/resources/data/spectrum/worldgen/placed_feature/pyrite_ripper_wall_patch.json
+++ b/src/main/resources/data/spectrum/worldgen/placed_feature/pyrite_ripper_wall_patch.json
@@ -22,17 +22,6 @@
     },
     {
       "type": "minecraft:biome"
-    },
-    {
-      "type": "minecraft:block_predicate_filter",
-      "predicate": {
-        "type": "minecraft:not",
-        "predicate": {
-          "type": "exclusions_lib:overlaps_structure",
-          "structures": "#spectrum:no_wall_features",
-          "range": 6
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
Just a cherry-pick of 695e19766dfe7ba3265290bc7b0102253ee98209. Would be very nice to have this in the 1.20.1 version