### PR TITLE
Fixed Idols getting stuck in their cooldown state when moved during it

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/idols/IdolBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/idols/IdolBlock.java
@@ -59,6 +59,14 @@ public abstract class IdolBlock extends Block {
 	}
 	
 	@Override
+	protected void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston) {
+		super.onPlace(state, level, pos, oldState, movedByPiston);
+		if (!state.is(oldState.getBlock()) && !level.isClientSide() && state.getValue(COOLDOWN) && !level.getBlockTicks().hasScheduledTick(pos, this)) {
+			triggerCooldown(level, pos);
+		}
+	}
+	
+	@Override
 	public void tick(BlockState state, ServerLevel world, BlockPos pos, RandomSource random) {
 		super.tick(state, world, pos, random);
 		world.setBlockAndUpdate(pos, world.getBlockState(pos).setValue(COOLDOWN, false));


### PR DESCRIPTION
## Summary

This PR addresses an issue with Idols that caused them to get stuck on cooldown when moved from the spot they went on cooldown in.

## Problem

Currently, if one were to trigger this bug, they would have to break and replace their idol to get it out of its cooldown state. This discourages using Idols with pistons and other means of moving blocks.

## Changes

All Idols now re-schedule their cooldowns when replacing another block whilst their cooldown state is true

## Testing
<img width="1920" height="1080" alt="2026-06-01_17 37 30" src="https://github.com/user-attachments/assets/92d7c42d-49c1-4cbb-9484-c3f3f48f3066" />
Constructed the displayed setup, with the Vitriolic Idol now going off cooldown after being moved with a piston as expected. This setup, on the release version, would permanently lock the idol into its cooldown state.

## Improvements
Currently, the idols reschedule their block ticks with the provided ```triggerCooldown(Level, Pos)``` method, which also updates the blockstate to be on cooldown - however it already is in this case. This is my first PR ever, so I wanted to ask what approach would be preferred instead. My first idea was to split the cooldown methods into ```triggerCooldownAndUpdate(Level, Pos)``` and ```triggerCooldown(Level, Pos)```. It could also be a nonissue or I could use the raw scheduling call.