### PR TITLE
Block Placers now place blocks more reliably and set themselves as changed when doing so.

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
@@ -78,23 +78,33 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements Entity
 	protected void tryPlace(ItemStack stack, BlockSource pointer, @Nullable Player owner) {
 		Level world = pointer.level();
 		if (stack.getItem() instanceof BlockItem blockItem) {
-			Direction facing = pointer.state().getValue(BlockPlacerBlock.ORIENTATION).front();
-			BlockPos placementPos = pointer.pos().relative(facing);
-			Direction placementDirection = world.isEmptyBlock(placementPos.below()) ? facing : Direction.UP;
+			FrontAndTop frontAndTop = pointer.state().getValue(BlockPlacerBlock.ORIENTATION);
+			Direction frontFacing = frontAndTop.front();
+			BlockPos placementPos = pointer.pos().relative(frontFacing);
+
+			// This must be horizontal because it being vertical may break assumptions made by blocks in their placement logic
+			Direction horizontalPlacementDirection;
+			if (frontAndTop.front().getAxis() == Direction.Axis.Y) {
+				horizontalPlacementDirection = frontAndTop.top().getOpposite();
+			} else {
+				horizontalPlacementDirection = frontAndTop.front().getOpposite();
+			}
+			// Represents the face of the selected block the player would have clicked to place this block here
+			Direction simulatedClickedFace = world.isEmptyBlock(placementPos.below()) ? frontFacing : Direction.UP;
 			
 			if (!GenericClaimModsCompat.canPlaceBlock(world, placementPos, owner)) {
 				return;
 			}
 			
 			try {
-				if (blockItem.place(new BlockPlacerPlacementContext(world, placementPos, facing, stack, placementDirection, owner)).consumesAction()) {
+				if (blockItem.place(new BlockPlacerPlacementContext(world, placementPos, frontFacing, horizontalPlacementDirection, stack, simulatedClickedFace, owner)).consumesAction()) {
 					if (owner != null && owner.getAbilities().instabuild) {
 						stack.shrink(1);
 					}
 				}
 				;
 				world.levelEvent(LevelEvent.SOUND_DISPENSER_DISPENSE, pointer.pos(), 0);
-				world.levelEvent(LevelEvent.PARTICLES_SHOOT_SMOKE, pointer.pos(), pointer.state().getValue(BlockPlacerBlock.ORIENTATION).front().get3DDataValue());
+				world.levelEvent(LevelEvent.PARTICLES_SHOOT_SMOKE, pointer.pos(), frontFacing.get3DDataValue());
 				world.gameEvent(null, GameEvent.BLOCK_PLACE, placementPos);
 			} catch (Exception e) {
 				SpectrumCommon.logError("Block Placer encountered an error placing a block at " + placementPos + " when placing " + BuiltInRegistries.ITEM.getKey(blockItem));
@@ -151,11 +161,13 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements Entity
 		
 		// Shadows the variable facing in the superclass.
 		private final Direction facing;
-		private final Player cause;
+		private final Direction horizontalPlacementDirection;
+		private final @Nullable Player cause;
 		
-		public BlockPlacerPlacementContext(Level world, BlockPos pos, Direction facing, ItemStack stack, Direction side, Player cause) {
-			super(world, pos, facing, stack, side);
+		public BlockPlacerPlacementContext(Level world, BlockPos pos, Direction facing, Direction horizontalPlacementDirection, ItemStack stack, Direction simulatedClickedFace, @Nullable Player cause) {
+			super(world, pos, horizontalPlacementDirection, stack, simulatedClickedFace);
 			this.facing = facing;
+			this.horizontalPlacementDirection = horizontalPlacementDirection;
 			this.cause = cause;
 		}
 
@@ -167,7 +179,12 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements Entity
 		
 		@Override
 		public Direction getHorizontalDirection() {
-			return facing.getOpposite();
+			return this.horizontalPlacementDirection;
+		}
+		
+		@Override
+		public Direction getNearestLookingVerticalDirection() {
+			return this.facing.getAxis() == Direction.Axis.Y ? this.facing : Direction.UP;
 		}
 		
 		// SlabBlocks cause a non-funny StackOverflowError

--- a/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/redstone/BlockPlacerBlock.java
@@ -66,6 +66,9 @@ public class BlockPlacerBlock extends RedstoneInteractionBlock implements Entity
 			} else {
 				ItemStack stack = blockEntity.getItem(slot);
 				tryPlace(stack, pointer, blockEntity.getOwnerIfOnline(world));
+				// must set changed because getting stack and decrementing it doesn't inherently proc this
+				// thus comparators don't update automatically unless we do this
+				blockEntity.setChanged();
 			}
 		}
 	}


### PR DESCRIPTION
## Summary:
- Block Placers now adhere more strictly to the BlockPlaceContext contract and break less assumptions made by certain blocks
- Block Placers now set themselves as changed following a dispensing operation. 

## Problems:
- Block Placers currently are passing their unsanitized facing direction to a method that only takes horizontal facing directions. This causes logger spam and placement failure when attempting to place blocks with horizontal-only blockstates that assume said method only provides horizontal directions - such as Anvils and Blast Furnaces.
- Block Placers currently decrement their stack after placement both via the ```ItemStack.shrink(int)``` method and indirectly via the placement method in BlockItem, neither of which set the block entity as changed inherently because they only modify the stack itself instead of the block entity. This causes issues when trying to use a comparator to read when the Block Placer empties its inventory of items and turn it off - the comparator requires an external update to properly read the Block Placer's contents.

## Changes:
- Block Placer now determines a ```horizontalPlacementDirection``` which is provided to ```BlockPlacerPlacementContext``` as a field and defaults to the front face of the Block Placer - if said front face is on the Y axis, the top face will be used instead as that's guaranteed to be horizontal in that case. The ```horizontalPlacementDirection``` is also inverted for consistency with the previous placement behavior of the Block Placer.
- BlockPlacerPlacementContext now overrides ```BlockPlaceContext.getNearestLookingVerticalDirection()``` which previously attempted to pull from the player's view angle, but caused a placement failure because Pointed Dripstone is the only block that uses that and it isn't in the placement credit whitelist tag. It now pulls from the front-facing direction of the Block Placer if it's on the Y axis, but defaults to up.
- Added a ```horizontalPlacementDirection``` field to ```BlockPlacerPlacementContext``` that is now used instead of
- ```BlockEntity.setChanged()``` is now called following the ```BlockPlacerBlock.tryPlace(ItemStack, BlockSource, Player)``` call to cover any possible changes that may have been made to the inventory of the Block Placer during its run.

## Testing
- I tested multple setups including a Block Placer placing another Block Placer in an instance running the latest published Fabric release, and the outputs all matched the outputs achieved with the new logic.

## Improvements:
- The logic to decrement the placed block stack even if the owner is in Creative seems a bit brittle. I haven't worked with them too extensively, but a fake player set to Survival may be more stable in this instance in case a mod hooks into ```BlockItem.place()``` and adds custom logic to it.