### PR TITLE
Fabric 1.21.1 - Fix LC fluid interaction dupe, fix swimming

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/fluid/LiquidCrystalFluidBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/fluid/LiquidCrystalFluidBlock.java
@@ -53,9 +53,9 @@ public class LiquidCrystalFluidBlock extends SpectrumFluidBlock {
 	@Override
 	public @Nullable BlockState handleFluidCollision(Level world, FluidState state, FluidState otherState, Direction direction) {
 		if (otherState.is(FluidTags.WATER)) {
-			return state.isSource() ? SpectrumBlocks.FROSTBITE_CRYSTAL.defaultBlockState() : Blocks.CALCITE.defaultBlockState();
+			return state.isSource() && direction != Direction.DOWN ? SpectrumBlocks.FROSTBITE_CRYSTAL.defaultBlockState() : Blocks.CALCITE.defaultBlockState();
 		} else if (otherState.is(FluidTags.LAVA)) {
-			return state.isSource() ? SpectrumBlocks.BLAZING_CRYSTAL.defaultBlockState() : Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+			return state.isSource() && direction != Direction.DOWN ? SpectrumBlocks.BLAZING_CRYSTAL.defaultBlockState() : Blocks.COBBLED_DEEPSLATE.defaultBlockState();
 		} else if (otherState.is(SpectrumFluidTags.SLUDGE)) {
 			return Blocks.CLAY.defaultBlockState();
 		}

--- a/src/main/resources/spectrum.mixins.json
+++ b/src/main/resources/spectrum.mixins.json
@@ -25,6 +25,7 @@
     "EnderEyeItemMixin",
     "EndermanEntityMixin",
     "EntityApplyFluidsMixin",
+    "EntityApplyFluidsMixinNoSinytra",
     "EntityMixin",
     "EntityStatusEffectsS2CPacketMixin",
     "EntityTypeMixin",


### PR DESCRIPTION
The fluid collision thing feels clunky but it should work so uh, shrug?

The mixin could have been merged into the other one to reduce confusion but this works as a quick fix.

I've tested the mixin and it fixes it all fine, but can't test the fluid interaction thing as the API's down and `runClient` just hangs.