### PR TITLE
Fix a crash with ledger when fishing/primordial burning

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/entity/entity/FireproofItemEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/entity/entity/FireproofItemEntity.java
@@ -25,17 +25,9 @@ public class FireproofItemEntity extends ItemEntity {
 		this.setItem(stack);
 	}
 	
-	private FireproofItemEntity(ItemEntity entity) {
-		super(SpectrumEntityTypes.FIREPROOF_ITEM, entity.level());
-	}
-	
 	@Override
 	public boolean isInvulnerableTo(DamageSource damageSource) {
 		return damageSource.is(DamageTypeTags.IS_FIRE) || super.isInvulnerableTo(damageSource);
-	}
-	
-	public ItemEntity copy() {
-		return new FireproofItemEntity(this);
 	}
 	
 	public static void scatter(Level world, double x, double y, double z, ItemStack stack) {

--- a/src/main/java/de/dafuqs/spectrum/entity/entity/FireproofItemEntity.java
+++ b/src/main/java/de/dafuqs/spectrum/entity/entity/FireproofItemEntity.java
@@ -31,7 +31,7 @@ public class FireproofItemEntity extends ItemEntity {
 	}
 	
 	public static void scatter(Level world, double x, double y, double z, ItemStack stack) {
-		double d = EntityType.ITEM.getWidth();
+		double d = SpectrumEntityTypes.FIREPROOF_ITEM.getWidth();
 		double e = 1.0 - d;
 		double f = d / 2.0;
 		double g = Math.floor(x) + world.getRandom().nextDouble() * e + f;


### PR DESCRIPTION
Ledger tries to copy the entity, and uh. Gets an entity with nothing in it. And then tries to encode *that* and oops, crash

We don't need a custom copy or constructor as the ItemEntity already copies the entity type over