### PR TITLE
Make singleink storage check ink acceptance more

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/api/energy/storage/FixedSingleInkStorage.java
+++ b/src/main/java/de/dafuqs/spectrum/api/energy/storage/FixedSingleInkStorage.java
@@ -17,14 +17,5 @@ public class FixedSingleInkStorage extends SingleInkStorage {
 	public boolean accepts(InkColor color) {
 		return this.storedColor == color;
 	}
-	
-	@Override
-	public long getRoom(InkColor color) {
-		if (this.storedColor == color) {
-			return this.maxEnergy - this.storedEnergy;
-		} else {
-			return 0;
-		}
-	}
-	
+
 }

--- a/src/main/java/de/dafuqs/spectrum/api/energy/storage/SingleInkStorage.java
+++ b/src/main/java/de/dafuqs/spectrum/api/energy/storage/SingleInkStorage.java
@@ -41,10 +41,11 @@ public class SingleInkStorage implements InkStorage {
 	
 	@Override
 	public long addEnergy(InkColor color, long amount) {
-		if (color != storedColor && this.storedEnergy != 0)
+		if (color != storedColor && this.storedEnergy != 0 || !this.accepts(color))
 			return amount;
-		if (this.storedEnergy == 0)
+		if (this.storedEnergy == 0) {
 			this.storedColor = color;
+		}
 		long resultingAmount = this.storedEnergy + amount;
 		this.storedEnergy = resultingAmount;
 		if (resultingAmount > this.maxEnergy) {
@@ -138,7 +139,7 @@ public class SingleInkStorage implements InkStorage {
 	
 	@Override
 	public long getRoom(InkColor color) {
-		if (this.storedEnergy == 0 || this.storedColor == color) {
+		if (this.accepts(color)) {
 			return this.maxEnergy - this.storedEnergy;
 		} else {
 			return 0;


### PR DESCRIPTION
Lets us simplify the subsclasses some.

Also makes sure that some addon doesn't accidentally push wrong color of ink into an item that shouldn't accept any, if they skip `accepts`, as `addEnergy` can generally be called with wrong colors either way.