### PR TITLE
Don't wirelessly link an ItemStack's component to a live player

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/mixin/LivingEntityMixin.java
+++ b/src/main/java/de/dafuqs/spectrum/mixin/LivingEntityMixin.java
@@ -213,7 +213,7 @@ public abstract class LivingEntityMixin {
 	private void spectrum$applyConcealedEffects(Level world, ItemStack stack, FoodProperties foodComponent, CallbackInfoReturnable<ItemStack> cir) {
 		var oilEffect = stack.get(SpectrumDataComponentTypes.CONCEALED_EFFECT);
 		if (!world.isClientSide() && oilEffect != null)
-			((LivingEntity) (Object) this).addEffect(oilEffect);
+			((LivingEntity) (Object) this).addEffect(new MobEffectInstance(oilEffect));
 	}
 	
 	@ModifyReturnValue(method = "canBeAffected", at = @At("RETURN"))


### PR DESCRIPTION
Per neoforge docs (but it's a minecraft's own class, they just documented some about it):
> `MobEffectInstances` are mutable. If you need a copy, call `new MobEffectInstance(oldInstance)`.

Stops the item stack from having an effect updated by the player's effect ticking down. Or whatever might be going on in the depths of minecraft codebase.

Also behaved really oddly (crash potentially?) when you tried to store it in some mods' special item containers