### PR TITLE
Fix wrong check in Neoforge 1.21.1 particle payload

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/networking/s2c_payloads/PlayParticleAroundBlockSidesPayload.java
+++ b/src/main/java/de/dafuqs/spectrum/networking/s2c_payloads/PlayParticleAroundBlockSidesPayload.java
@@ -33,7 +33,7 @@ public record PlayParticleAroundBlockSidesPayload(BlockPos pos, int quantity, Ve
 		Packet<?> packet = new ClientboundCustomPayloadPacket(new PlayParticleAroundBlockSidesPayload(pos, quantity, velocity, particleEffect, sides));
 		
 		for (ServerPlayer player : level.getChunkSource().chunkMap.getPlayers(new ChunkPos(pos), false)) {
-			if (sendCheck.test(player))
+			if (!sendCheck.test(player))
 				continue;
 			
 			player.connection.send(packet);


### PR DESCRIPTION
i havent tested this but it matches what the fabric version does: https://github.com/DaFuqs/Spectrum/blob/0d1f13e931a00244c2fd245f1343ff1d3d4af8ca/src/main/java/de/dafuqs/spectrum/networking/s2c_payloads/PlayParticleAroundBlockSidesPayload.java#L32