### PR TITLE
A small fix for farmers delight cutting compat, and adds a new cutting recipe for noxcaps

### DIFF
--- a/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/chestnut_noxcap_stem.json
+++ b/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/chestnut_noxcap_stem.json
@@ -1,0 +1,37 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "spectrum:chestnut_noxcap_stem"
+    }
+  ],
+  "result": [
+    {
+      "item": {
+        "count": 1,
+        "id": "spectrum:stripped_chestnut_noxcap_stem"
+      }
+    },
+    {
+      "item": {
+        "count": 1,
+        "id": "spectrum:myceylon"
+      }
+    }
+  ],
+  "tool": [
+    {
+      "type": "farmersdelight:item_ability",
+      "action": "axe_strip"
+    },
+    {
+      "tag": "minecraft:axes"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "farmersdelight"
+    }
+  ]
+}

--- a/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/citrine_block.json
+++ b/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/citrine_block.json
@@ -13,10 +13,15 @@
       }
     }
   ],
-  "tool": {
-    "type": "farmersdelight:item_ability",
-    "action": "pickaxe_dig"
-  },
+  "tool": [
+    {
+      "type": "farmersdelight:item_ability",
+      "action": "pickaxe:dig"
+    },
+    {
+      "tag": "minecraft:pickaxes"
+    }
+  ],
   "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",

--- a/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/ebony_noxcap_stem.json
+++ b/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/ebony_noxcap_stem.json
@@ -1,0 +1,37 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "spectrum:ebony_noxcap_stem"
+    }
+  ],
+  "result": [
+    {
+      "item": {
+        "count": 1,
+        "id": "spectrum:stripped_ebony_noxcap_stem"
+      }
+    },
+    {
+      "item": {
+        "count": 1,
+        "id": "spectrum:myceylon"
+      }
+    }
+  ],
+  "tool": [
+    {
+      "type": "farmersdelight:item_ability",
+      "action": "axe_strip"
+    },
+    {
+      "tag": "minecraft:axes"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "farmersdelight"
+    }
+  ]
+}

--- a/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/ivory_noxcap_stem.json
+++ b/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/ivory_noxcap_stem.json
@@ -1,0 +1,37 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "spectrum:ivory_noxcap_stem"
+    }
+  ],
+  "result": [
+    {
+      "item": {
+        "count": 1,
+        "id": "spectrum:stripped_ivory_noxcap_stem"
+      }
+    },
+    {
+      "item": {
+        "count": 1,
+        "id": "spectrum:myceylon"
+      }
+    }
+  ],
+  "tool": [
+    {
+      "type": "farmersdelight:item_ability",
+      "action": "axe_strip"
+    },
+    {
+      "tag": "minecraft:axes"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "farmersdelight"
+    }
+  ]
+}

--- a/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/moonstone_block.json
+++ b/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/moonstone_block.json
@@ -13,10 +13,15 @@
       }
     }
   ],
-  "tool": {
-    "type": "farmersdelight:item_ability",
-    "action": "pickaxe_dig"
-  },
+  "tool": [
+    {
+      "type": "farmersdelight:item_ability",
+      "action": "pickaxe:dig"
+    },
+    {
+      "tag": "minecraft:pickaxes"
+    }
+  ],
   "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",

--- a/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/onyx_block.json
+++ b/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/onyx_block.json
@@ -13,10 +13,15 @@
       }
     }
   ],
-  "tool": {
-    "type": "farmersdelight:item_ability",
-    "action": "pickaxe_dig"
-  },
+  "tool": [
+    {
+      "type": "farmersdelight:item_ability",
+      "action": "pickaxe:dig"
+    },
+    {
+      "tag": "minecraft:pickaxes"
+    }
+  ],
   "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",

--- a/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/slate_noxcap_stem.json
+++ b/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/slate_noxcap_stem.json
@@ -1,0 +1,37 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "spectrum:slate_noxcap_stem"
+    }
+  ],
+  "result": [
+    {
+      "item": {
+        "count": 1,
+        "id": "spectrum:stripped_slate_noxcap_stem"
+      }
+    },
+    {
+      "item": {
+        "count": 1,
+        "id": "spectrum:myceylon"
+      }
+    }
+  ],
+  "tool": [
+    {
+      "type": "farmersdelight:item_ability",
+      "action": "axe_strip"
+    },
+    {
+      "tag": "minecraft:axes"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "farmersdelight"
+    }
+  ]
+}

--- a/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/topaz_block.json
+++ b/src/main/resources/data/spectrum/recipe/mod_integration/farmersdelight/cutting/topaz_block.json
@@ -13,10 +13,15 @@
       }
     }
   ],
-  "tool": {
-    "type": "farmersdelight:item_ability",
-    "action": "pickaxe_dig"
-  },
+  "tool": [
+    {
+      "type": "farmersdelight:item_ability",
+      "action": "pickaxe:dig"
+    },
+    {
+      "tag": "minecraft:pickaxes"
+    }
+  ],
   "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",


### PR DESCRIPTION
Fixes an issue with gemstone cutting recipes not accepting multitools and the malachite staff in gemstone block splitting recipes.

Also adds cutting recipes to noxcaps for making myceylon and stripped noxcaps, but there could also be a good reason for this to not exist that i dont know about.