### PR TITLE
fix recently added tags

### DIFF
--- a/src/main/resources/data/c/tags/item/gems.json
+++ b/src/main/resources/data/c/tags/item/gems.json
@@ -1,5 +1,5 @@
 {
   "values": [
-    "spectrum:gemstone_shards"
+    "#spectrum:gemstone_shards"
   ]
 }

--- a/src/main/resources/data/spectrum/tags/item/blackslag_ores.json
+++ b/src/main/resources/data/spectrum/tags/item/blackslag_ores.json
@@ -1,0 +1,19 @@
+{
+  "values": [
+    "spectrum:blackslag_coal_ore",
+    "spectrum:blackslag_copper_ore",
+    "spectrum:blackslag_iron_ore",
+    "spectrum:blackslag_gold_ore",
+    "spectrum:blackslag_diamond_ore",
+    "spectrum:blackslag_redstone_ore",
+    "spectrum:blackslag_lapis_ore",
+    "spectrum:blackslag_emerald_ore",
+    "spectrum:blackslag_shimmerstone_ore",
+    "spectrum:blackslag_malachite_ore",
+    "spectrum:blackslag_amethyst_ore",
+    "spectrum:blackslag_citrine_ore",
+    "spectrum:blackslag_topaz_ore",
+    "spectrum:blackslag_onyx_ore",
+    "spectrum:blackslag_moonstone_ore"
+  ]
+}


### PR DESCRIPTION
1.21.7 added some tags, but LMFT and KubeJS complained about them:

```
[19:29:43] [Worker-ResourceReload-10/WARN] [io.wi.lm.LMFTCommon/]: [Load My F***ing Tags]: Couldn't load certain entries within the tag c:ore_rates/sparse: #spectrum:blackslag_ores (from mod/spectrum)
[19:29:43] [Worker-ResourceReload-10/WARN] [io.wi.lm.LMFTCommon/]: [Load My F***ing Tags]: Couldn't load certain entries within the tag c:gems: spectrum:gemstone_shards (from mod/spectrum)
[19:29:43] [Render thread/ERROR] [KubeJS/]: Couldn't load tag c:ore_rates/sparse as it is missing following references: 
  #spectrum:blackslag_ores (from mod/spectrum)
[19:29:43] [Render thread/ERROR] [KubeJS/]: Couldn't load tag c:gems as it is missing following references: 
  spectrum:gemstone_shards (from mod/spectrum)
```